### PR TITLE
fix: commit missing generated docs from #6

### DIFF
--- a/.claude/agents/terraform-provider-code-reviewer.md
+++ b/.claude/agents/terraform-provider-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: "terraform-provider-code-reviewer"
 description: "Use this agent proactively when you need to review recently written or modified code in the terraform-provider-anthropic repository for quality and security issues. This includes reviewing Go source files, GitHub Actions workflow files, and Terraform configuration files. Trigger this agent after writing new resources, data sources, tests, workflows, or Terraform examples. You must tell the agent precisely which files to review.\\n\\n<example>\\nContext: The user has just implemented a new Terraform resource in the provider.\\nuser: \"I've just written the new model resource in internal/provider/model_resource.go and added an example under examples/resources/anthropic_model/\"\\nassistant: \"Great, let me launch the code reviewer to check quality and security issues on your new resource.\"\\n<commentary>\\nSince new Go and Terraform code was written, use the Agent tool to launch the tf-provider-code-reviewer agent to review the code.\\n</commentary>\\nassistant: \"I'll use the tf-provider-code-reviewer agent to review the new model resource and its example.\"\\n</example>\\n\\n<example>\\nContext: The user has added a new GitHub Actions workflow.\\nuser: \"I added .github/workflows/release.yml to handle automated releases\"\\nassistant: \"Let me use the tf-provider-code-reviewer agent to audit the new workflow for security issues.\"\\n<commentary>\\nSince a GitHub Actions workflow was added, use the Agent tool to launch the tf-provider-code-reviewer agent to check for supply chain attack risks and credential leaks.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has added Terraform example configurations under examples/.\\nuser: \"I created examples/resources/anthropic_model_alias/ with main.tf and variables.tf\"\\nassistant: \"I'll launch the tf-provider-code-reviewer to verify the example includes .tftest.hcl unit tests and follows conventions.\"\\n<commentary>\\nSince new Terraform example code was added, use the Agent tool to launch the tf-provider-code-reviewer agent to check for .tftest.hcl test files.\\n</commentary>\\n</example>"
-tools: Bash, CronCreate, CronDelete, CronList, EnterWorktree, ExitWorktree, Glob, Grep, ListMcpResourcesTool, Monitor, Read, ReadMcpResourceTool, RemoteTrigger, ScheduleWakeup, Skill, TaskCreate, TaskGet, TaskList, TaskUpdate, ToolSearch, WebFetch, WebSearch, mcp__claude_ai_Asana__authenticate, mcp__claude_ai_Asana__complete_authentication, mcp__claude_ai_Atlassian__authenticate, mcp__claude_ai_Atlassian__complete_authentication, mcp__claude_ai_Box__authenticate, mcp__claude_ai_Box__complete_authentication, mcp__claude_ai_Canva__authenticate, mcp__claude_ai_Canva__complete_authentication, mcp__claude_ai_Excalidraw__create_view, mcp__claude_ai_Excalidraw__export_to_excalidraw, mcp__claude_ai_Excalidraw__read_checkpoint, mcp__claude_ai_Excalidraw__read_me, mcp__claude_ai_Excalidraw__save_checkpoint, mcp__claude_ai_FFJ_-_Dossier_de_Financement__greet, mcp__claude_ai_Gamma__authenticate, mcp__claude_ai_Gamma__complete_authentication, mcp__claude_ai_Gmail__authenticate, mcp__claude_ai_Gmail__complete_authentication, mcp__claude_ai_Google_Calendar__authenticate, mcp__claude_ai_Google_Calendar__complete_authentication, mcp__claude_ai_HubSpot__authenticate, mcp__claude_ai_HubSpot__complete_authentication, mcp__claude_ai_Intercom__authenticate, mcp__claude_ai_Intercom__complete_authentication, mcp__claude_ai_Linear__authenticate, mcp__claude_ai_Linear__complete_authentication, mcp__claude_ai_Miro__authenticate, mcp__claude_ai_Miro__complete_authentication, mcp__claude_ai_monday_com__authenticate, mcp__claude_ai_monday_com__complete_authentication, mcp__claude_ai_Notion__authenticate, mcp__claude_ai_Notion__complete_authentication, mcp__claude_ai_Sentry__authenticate, mcp__claude_ai_Sentry__complete_authentication, mcp__claude_ai_Slack__authenticate, mcp__claude_ai_Slack__complete_authentication, mcp__github__authenticate, mcp__github__complete_authentication, mcp__ide__getDiagnostics
+tools: Bash, Glob, Grep, Read, mcp__ide__getDiagnostics
 model: opus
 color: pink
 memory: project
@@ -88,7 +88,10 @@ Apply the following security checks rigorously to prevent supply chain attacks a
 Structure your review as follows:
 
 ```
-## Code Review Summary
+## Code Review summary
+
+### 🔍 Overview
+- Brief overview of what you reviewed and overall assessment (e.g., "Good, minor issues found" or "Significant security concerns")
 
 ### 🔴 Critical Issues (must fix)
 - [File:Line] Issue description and recommended fix
@@ -101,6 +104,14 @@ Structure your review as follows:
 
 ### 📋 Recommendations (nice to have)
 - Suggestions for improvement
+
+### ✅ Approval status
+- Clear statement of whether the code is ready to merge/deploy or requires changes
+
+### 🚧 Obstacles encountered
+- Report any obstacle encountered during the code review process. This can be: setup issues, workarounds discovered or environment quirks.
+- Report commands that needed a special flag or configuration.
+- Report dependencies or imports that caused problems.
 ```
 
 Be specific: cite file names, line numbers when possible, and provide concrete fix examples. Do not pad the review with vague praise — focus on actionable findings.

--- a/.github/workflows/goreleaser-snapshot.yml
+++ b/.github/workflows/goreleaser-snapshot.yml
@@ -1,7 +1,7 @@
 name: GoReleaser Snapshot
 
 on:
-  pull_request:
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -2,6 +2,7 @@ name: Provider
 
 on:
   pull_request:
+  merge_group:
 
 permissions: {}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Environment
+
+A `.env` file at the project root sets machine-specific variables (e.g., `OTEL_TRACES_EXPORTER=`). **Always source it before running any command** to avoid env-related failures:
+
+```bash
+set -a && source .env && set +a
+```
+
 ## Commands
 
 ```bash

--- a/docs/data-sources/models.md
+++ b/docs/data-sources/models.md
@@ -58,7 +58,29 @@ Read-Only:
 - `batch` (Boolean) Whether the model supports the Batch API.
 - `citations` (Boolean) Whether the model supports citation generation.
 - `code_execution` (Boolean) Whether the model supports code execution tools.
+- `context_management` (Attributes) Context management strategy support. (see [below for nested schema](#nestedatt--models--capabilities--context_management))
+- `effort` (Attributes) Reasoning effort (reasoning_effort) level support. (see [below for nested schema](#nestedatt--models--capabilities--effort))
 - `image_input` (Boolean) Whether the model accepts image content blocks.
 - `pdf_input` (Boolean) Whether the model accepts PDF content blocks.
 - `structured_outputs` (Boolean) Whether the model supports structured output / JSON mode.
 - `thinking` (Boolean) Whether the model supports extended thinking.
+
+<a id="nestedatt--models--capabilities--context_management"></a>
+### Nested Schema for `models.capabilities.context_management`
+
+Read-Only:
+
+- `clear_thinking_20251015` (Boolean) Whether the model supports the `clear_thinking_20251015` context management strategy.
+- `clear_tool_uses_20250919` (Boolean) Whether the model supports the `clear_tool_uses_20250919` context management strategy.
+- `compact_20260112` (Boolean) Whether the model supports the `compact_20260112` context management strategy.
+
+
+<a id="nestedatt--models--capabilities--effort"></a>
+### Nested Schema for `models.capabilities.effort`
+
+Read-Only:
+
+- `high` (Boolean) Whether the model supports `high` effort level.
+- `low` (Boolean) Whether the model supports `low` effort level.
+- `max` (Boolean) Whether the model supports `max` effort level.
+- `medium` (Boolean) Whether the model supports `medium` effort level.

--- a/docs/resources/message.md
+++ b/docs/resources/message.md
@@ -14,6 +14,17 @@ Sends a message to an Anthropic model via the Messages API and stores the respon
 ## Example Usage
 
 ```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    anthropic = {
+      source  = "registry.terraform.io/ippontech/anthropic"
+      version = "~> 1.0"
+    }
+  }
+}
+
 resource "anthropic_message" "example" {
   model      = "claude-haiku-4-5-20251001"
   max_tokens = 1024
@@ -87,7 +98,7 @@ output "conversation_response" {
 
 ### Read-Only
 
-- `content` (String) The generated text response from the model.
+- `content` (String) The generated text response from the model. Only `text` content blocks are included; other block types (e.g., `thinking`) are omitted.
 - `id` (String) Unique message identifier assigned by the API.
 - `input_tokens` (Number) Number of input tokens used in the request.
 - `output_tokens` (Number) Number of output tokens generated in the response.


### PR DESCRIPTION
## Summary

- Fix the failing `generate` CI job from #6 by committing the docs that `make generate` produces
- Add required status checks for main branch and update workflows accordingly
- `docs/data-sources/models.md`: adds missing `context_management` and `effort` nested schema sections
- `docs/resources/message.md`: adds provider block to example and updates `content` attribute description
- `CLAUDE.md`: documents that `.env` must be sourced before running any project command
- `.claude/agents/terraform-provider-code-reviewer.md`: restrict agent tools to read-only set (Read, Glob, Grep, Bash, getDiagnostics)

## Root cause

`make generate` was not run before merging #6, so the regenerated docs were never committed. The `generate` CI job runs `make generate` and then fails if there are uncommitted changes.

## Test plan

- [x] `generate` CI job passes (no uncommitted changes after `make generate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)