### PR TITLE
chore(ci): setup Renovate for automated dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,29 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Every Monday at 4am UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":dependencyDashboard"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 6am on Monday"],
+  "prConcurrentLimit": 10,
+  "enabledManagers": [
+    "github-actions",
+    "gomod",
+    "mise",
+    "pre-commit",
+    "terraform"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "Go dependencies",
+      "groupSlug": "go-deps"
+    },
+    {
+      "matchManagers": ["mise"],
+      "groupName": "mise tools",
+      "groupSlug": "mise-tools"
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit hooks",
+      "groupSlug": "pre-commit"
+    }
+  ]
+}

--- a/tools/.poutine.yml
+++ b/tools/.poutine.yml
@@ -6,3 +6,4 @@ skip:
       - pkg:githubactions/golangci/golangci-lint-action
       - pkg:githubactions/rhysd/actionlint
       - pkg:githubactions/semgrep/semgrep-action
+      - pkg:githubactions/renovatebot/github-action


### PR DESCRIPTION
## Summary

Sets up [Renovate](https://github.com/renovatebot/github-action) to automate dependency updates across all ecosystems in this repository.

## What's included

### `renovate.json`
Comprehensive Renovate configuration covering:
- **GitHub Actions** — updates SHA-pinned actions, grouped into a single PR
- **Go modules** — minor and patch updates grouped, major updates individual
- **pre-commit hooks** — all hook versions grouped
- **mise tools** — all tool versions grouped (`go`, `golangci-lint`, `goreleaser`, `terraform`, `poutine`)
- **Terraform providers** — provider version constraints and lock file

Additional settings:
- `chore(deps):` semantic commit prefix (matches repo conventions)
- Dependency Dashboard issue for visibility
- Weekly schedule (Mondays before 6am UTC) to avoid noise
- Max 10 concurrent PRs

### `.github/workflows/renovate.yml`
Self-hosted Renovate workflow:
- Triggered weekly (Monday 4am UTC) and on `workflow_dispatch`
- SHA-pinned `renovatebot/github-action@eb932558` (v46.1.9)
- Hardened runner with `egress-policy: audit`
- Uses `RENOVATE_TOKEN` secret

### `tools/.poutine.yml`
Adds `renovatebot/github-action` to the poutine allowlist (unverified creator exception, same pattern as `golangci/golangci-lint-action`).

## Required setup

Before this workflow can run, add a `RENOVATE_TOKEN` secret to the repository:
1. Create a fine-grained PAT (or classic PAT with `repo` scope) for a bot account
2. Add it as a repository secret named `RENOVATE_TOKEN`
3. The token needs: **Contents** (write), **Pull requests** (write), **Issues** (write)

## Test plan

- [x] Merge this PR
- [x] Add `RENOVATE_TOKEN` repository secret
- [ ] Trigger the workflow manually via `workflow_dispatch` to validate the first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)