### PR TITLE
test: fix model data source acceptance test (deprecated model ID)

### DIFF
--- a/internal/provider/model_data_source_test.go
+++ b/internal/provider/model_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccModelDataSource(t *testing.T) {
 			{
 				Config: testAccModelDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.anthropic_model.test", "model_id", "claude-3-5-haiku-20241022"),
+					resource.TestCheckResourceAttr("data.anthropic_model.test", "model_id", "claude-haiku-4-5-20251001"),
 					resource.TestCheckResourceAttrSet("data.anthropic_model.test", "id"),
 					resource.TestCheckResourceAttrSet("data.anthropic_model.test", "display_name"),
 					resource.TestCheckResourceAttrSet("data.anthropic_model.test", "created_at"),
@@ -41,6 +41,6 @@ func TestAccModelDataSource(t *testing.T) {
 
 const testAccModelDataSourceConfig = `
 data "anthropic_model" "test" {
-  model_id = "claude-3-5-haiku-20241022"
+  model_id = "claude-haiku-4-5-20251001"
 }
 `


### PR DESCRIPTION
## Summary

- `TestAccModelDataSource` was failing on `main` because `claude-3-5-haiku-20241022` now returns HTTP 404 from the Anthropic API
- Updated the test to use the current Haiku 4.5 model ID: `claude-haiku-4-5-20251001`

## Test plan

- [x] Run `TF_ACC=1 go test -run TestAccModelDataSource -v ./internal/provider/ -timeout 120m` and confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)