### PR TITLE
docs: enrich CLAUDE.md with architecture-first layout and Terraform tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,51 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Architecture
+
+This is a Terraform provider built with [HashiCorp Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) v1.13.0.
+
+- `main.go` — entry point; serves the provider at `registry.terraform.io/ippontech/anthropic`
+- `internal/provider/provider.go` — provider registration; `Resources()` and `DataSources()` methods list all implemented resources and data sources
+- `internal/provider/` — all resources, data sources, and their tests live here
+- `examples/provider/` — example Terraform configs used by `terraform-plugin-docs` to generate `docs/`
+- `tests/` — Terraform native tests (`.tftest.hcl` files), one per resource/data source
+- `tools/tools.go` — build-time tool imports only (not runtime)
+
+### Implemented resources and data sources
+
+**Resources:**
+- `anthropic_message` (`internal/provider/message_resource.go`) — calls the Messages API; write-only, immutable (no read/update/delete)
+- `anthropic_agent` (`internal/provider/agent_resource.go`) — manages Managed Agents (create/read/update/delete)
+
+**Data sources:**
+- `anthropic_model` (`internal/provider/model_data_source.go`) — fetches a single model by ID
+- `anthropic_models` (`internal/provider/models_data_source.go`) — lists all available models
+- `anthropic_count_tokens` (`internal/provider/count_tokens_data_source.go`) — counts tokens for a given prompt
+
+### Adding a resource or data source
+
+1. Create `internal/provider/<name>_resource.go` (or `_data_source.go`)
+2. Implement the `resource.Resource` (or `datasource.DataSource`) interface
+3. Register the factory function in `Resources()` (or `DataSources()`) in `internal/provider/provider.go`
+4. Add an example config under `examples/resources/<name>/` (or `examples/data-sources/<name>/`)
+5. Add a Terraform native test under `tests/<name>.tftest.hcl`
+6. Run `make generate` to regenerate docs
+
+### Testing pattern
+
+**Go acceptance tests** (`internal/provider/`):
+- `internal/provider/provider_test.go` defines `testAccProtoV6ProviderFactories` used by all acceptance tests
+- Unit tests: no special env vars needed
+- Acceptance tests: use `resource.Test(t, resource.TestCase{...})` with `TF_ACC=1`
+
+**Terraform native tests** (`tests/`):
+- One `.tftest.hcl` file per resource/data source (e.g. `tests/message.tftest.hcl`)
+- Each test references the corresponding example config as its module source (e.g. `source = "./examples/resources/message"`)
+- Tests use `assert` blocks to verify computed attribute values
+- All test blocks set `parallel = true`
+- Run with `make terraform-test` (builds and installs the provider first via `.dev.tfrc`)
+
 ## Environment
 
 A `.env` file at the project root sets machine-specific variables (e.g., `OTEL_TRACES_EXPORTER=`). **Always source it before running any command** to avoid env-related failures:
@@ -13,51 +58,28 @@ set -a && source .env && set +a
 ## Commands
 
 ```bash
-make build       # Compile the provider
-make install     # Build and install locally
-make fmt         # Format Go code
-make lint        # Run golangci-lint
-make test        # Run unit tests (120s timeout, 10 parallel workers)
-make testacc     # Run acceptance tests (requires TF_ACC=1, 120m timeout)
-make generate    # Regenerate docs and format examples
-make             # Default: fmt lint install generate
+make build          # Compile the provider
+make install        # Build and install locally
+make fmt            # Format Go code
+make lint           # Run golangci-lint
+make test           # Run unit tests (120s timeout, 10 parallel workers)
+make testacc        # Run Go acceptance tests (requires TF_ACC=1, 120m timeout)
+make terraform-test # Run Terraform native tests (builds provider, uses .dev.tfrc)
+make generate       # Regenerate docs and format examples
+make                # Default: fmt lint install generate
 ```
 
-Run a single test:
+Run a single Go test:
 ```bash
 go test -run TestName -v ./internal/provider/
 ```
 
-Acceptance tests require `TF_ACC=1` and a real Anthropic API key.
+Go acceptance tests require `TF_ACC=1` and a real Anthropic API key. Terraform native tests also require a real API key and a locally installed provider.
 
 Before committing, run pre-commit hooks:
 ```bash
 pre-commit run -a
 ```
-
-## Architecture
-
-This is a Terraform provider built with [HashiCorp Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) v1.13.0.
-
-- `main.go` — entry point; serves the provider at `registry.terraform.io/ippontech/anthropic`
-- `internal/provider/provider.go` — provider registration; `Resources()` and `DataSources()` methods list all implemented resources and data sources
-- `internal/provider/` — all resources, data sources, and their tests live here
-- `examples/provider/` — example Terraform configs used by `terraform-plugin-docs` to generate `docs/`
-- `tools/tools.go` — build-time tool imports only (not runtime)
-
-### Adding a resource or data source
-
-1. Create `internal/provider/<name>_resource.go` (or `_data_source.go`)
-2. Implement the `resource.Resource` (or `datasource.DataSource`) interface
-3. Register the factory function in `Resources()` (or `DataSources()`) in `internal/provider/provider.go`
-4. Add an example config under `examples/resources/<name>/` (or `examples/data-sources/<name>/`)
-5. Run `make generate` to regenerate docs
-
-### Testing pattern
-
-- `internal/provider/provider_test.go` defines `testAccProtoV6ProviderFactories` used by all acceptance tests
-- Unit tests: no special env vars needed
-- Acceptance tests: use `resource.Test(t, resource.TestCase{...})` with `TF_ACC=1`
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- Moves Architecture section (and its subsections) to the top so Claude prioritises it as the most important context
- Adds an "Implemented resources and data sources" subsection listing all 5 current resources/data sources with file paths
- Enriches the Testing pattern section with a dedicated Terraform native tests block covering `.tftest.hcl` conventions, the `tests/` directory, module source pattern, `parallel = true`, and `make terraform-test`
- Adds step 5 to "Adding a resource or data source": create a `.tftest.hcl` file
- Adds `make terraform-test` to the Commands section

🤖 Generated with [Claude Code](https://claude.com/claude-code)