### PR TITLE
docs: add make default reminder after feature/bug fix implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ make generate       # Regenerate docs and format examples
 make                # Default: fmt lint install generate
 ```
 
+**After implementing any feature or bug fix, always run `make` (alias for `make default`) before committing.** It formats code, runs the linter, reinstalls the provider, and regenerates docs in one step.
+
 Run a single Go test:
 ```bash
 go test -run TestName -v ./internal/provider/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ make test           # Run unit tests (120s timeout, 10 parallel workers)
 make testacc        # Run Go acceptance tests (requires TF_ACC=1, 120m timeout)
 make terraform-test # Run Terraform native tests (builds provider, uses .dev.tfrc)
 make generate       # Regenerate docs and format examples
-make                # Default: fmt lint install generate
+make                # Default: fmt lint test install generate
 ```
 
 **After implementing any feature or bug fix, always run `make` (alias for `make default`) before committing.** It formats code, runs the linter, reinstalls the provider, and regenerates docs in one step.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-default: fmt lint install generate
+default: fmt lint test install generate
 
 build:
 	go build -v ./...


### PR DESCRIPTION
## Summary

- Adds a bolded reminder after the Commands table to always run `make` (i.e. `make default`) after implementing any feature or bug fix before committing
- `make default` runs `fmt lint install generate` in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)