### PR TITLE
fix: remove Stop hook to prevent vibe-kanban infinite loop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,18 +12,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "set -a; . ./.env 2>/dev/null; set +a; pre-commit run -a",
-            "timeout": 120,
-            "statusMessage": "Running pre-commit hooks..."
-          }
-        ]
-      }
     ]
   },
   "enabledPlugins": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ make generate       # Regenerate docs and format examples
 make                # Default: fmt lint install generate
 ```
 
+**After implementing any feature or bug fix, always run `make` (alias for `make default`) before committing.** It formats code, runs the linter, reinstalls the provider, and regenerates docs in one step.
+
 Run a single Go test:
 ```bash
 go test -run TestName -v ./internal/provider/


### PR DESCRIPTION
## Summary

- Removes the `Stop` hook from `.claude/settings.json`

## Why

The `Stop` hook ran `pre-commit run -a` every time Claude finished a turn (including when waiting for user input). In vibe-kanban, this fed the hook output back as a new message, which triggered another Claude response, which stopped again, firing the hook again — an infinite loop.

Pre-commit is already enforced as a native git hook (`pre-commit install`), so the Claude Code Stop hook is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)