### PR TITLE
fix: pre-install Terraform in testacc job to bypass expired GPG key

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
+
       - name: Run acceptance tests
         run: make testacc
         env:


### PR DESCRIPTION
## Summary

- Adds `hashicorp/setup-terraform` (with `terraform_wrapper: false`) to the `testacc` job

## Why

`terraform-plugin-testing` downloads the Terraform CLI at runtime and verifies its checksum signature against HashiCorp's embedded GPG key, which has now expired — causing all acceptance tests to fail with:

```
unable to verify checksums signature: openpgp: key expired
```

Pre-installing Terraform via `hashicorp/setup-terraform` before the tests run means the framework finds Terraform already on `$PATH` and skips the download + GPG verification entirely. This is the same approach already used by the `terraform-test` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)