### PR TITLE
chore: add vibe-kanban-brainstorming Claude skill

### DIFF
--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -76,11 +76,26 @@ Priority guidelines:
 - Resources: `high`
 - Data sources: `medium`
 
-### Step 4 — Create GitHub issues and branches
+### Step 4 — Create issue relationships
 
-For each subtask, in a **single parallel message**:
+After all Vibe Kanban issues exist, analyze dependencies between them and call
+`mcp__vibe_kanban__create_issue_relationship` for each pair. Use these rules:
+
+| Situation | `relationship_type` |
+|---|---|
+| Issue A must be merged before work on B can start | `blocking` (A → B) |
+| Resource and its corresponding data source(s) | `related` |
+| Single-item data source and its list data source | `related` |
+
+Run all `create_issue_relationship` calls in a **single parallel message**.
+
+If no dependencies exist between the issues, skip this step.
+
+### Step 5 — Create GitHub issues and branches
+
+For each issue, in a **single parallel message**:
 - `mcp__github__issue_write` (method: `create`) — mirror the Kanban description as a GitHub issue
-- `mcp__github__create_branch` (from `main`) — one branch per subtask
+- `mcp__github__create_branch` (from `main`) — one branch per issue
 
 Branch naming convention:
 - `anthropic_skill` resource → `feat/skill-resource`
@@ -88,7 +103,7 @@ Branch naming convention:
 - `anthropic_skill_version` resource → `feat/skill-version-resource`
 - `anthropic_skill_versions` data source → `feat/skill-versions-data-source`
 
-### Step 5 — Cross-link everything
+### Step 6 — Cross-link everything
 
 Update each Vibe Kanban issue description to add at the top:
 
@@ -99,7 +114,7 @@ Branch: feat/<name>
 
 Run all `mcp__vibe_kanban__update_issue` calls in a **single parallel message**.
 
-### Step 6 — Note on PRs
+### Step 7 — Note on PRs
 
 GitHub requires at least one commit before a PR can be opened. Always inform the user:
 
@@ -120,6 +135,7 @@ Each subtask description should reference:
 |---|---|
 | Fetch API docs pages | One `WebFetch` per page in a single message |
 | Create Vibe Kanban issues | One `create_issue` per issue in a single message |
+| Create issue relationships | One `create_issue_relationship` per pair in a single message |
 | Create GitHub issues + branches | All `issue_write` + `create_branch` calls in a single message |
 | Update Kanban issues with links | One `update_issue` per issue in a single message |
 | Implementation | All issues are independent — can be parallelized across agents |
@@ -181,6 +197,7 @@ User: "I'd like to implement /v1/environments APIs"
 1. Fetch `https://platform.claude.com/docs/en/api/overview` + all Environments endpoint pages in parallel
 2. Identify: `anthropic_environment` resource + `anthropic_environment` data source + `anthropic_environments` data source
 3. Create 3 Kanban issues in parallel (all `create_issue` in one message, no `parent_issue_id`)
-4. Create 3 GitHub issues + 3 branches in parallel (all in one message)
-5. Update 3 Kanban issues with links in parallel (all `update_issue` in one message)
-6. Report summary table to the user and remind them to open draft PRs after first commits
+4. Create relationships in parallel: resource `related` to single data source, single data source `related` to list data source
+5. Create 3 GitHub issues + 3 branches in parallel (all in one message)
+6. Update 3 Kanban issues with links in parallel (all `update_issue` in one message)
+7. Report summary table to the user and remind them to open draft PRs after first commits

--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: vibe-kanban-brainstorming
+description: >
+  Automates planning and scaffolding for implementing Anthropic API endpoints
+  as Terraform resources and data sources. Use when starting work on a new API
+  (e.g. /v1/skills, /v1/environments) to generate fully cross-linked Vibe Kanban
+  subtasks, GitHub issues, and branches — one per resource/data source — ready
+  for parallel implementation.
+model: sonnet
+---
+
+# vibe-kanban-brainstorming
+
+Use this skill when you need to plan and scaffold the implementation of a new
+Anthropic API as Terraform resources and data sources in this provider.
+
+## Trigger
+
+The user says something like:
+- "I'd like to implement /v1/environments APIs"
+- "Plan the work for the Files API"
+- "Create subtasks for the Sessions endpoints"
+
+## Workflow
+
+### Step 1 — Discover the API
+
+Fetch the API overview and all relevant endpoint pages:
+
+```
+WebFetch: https://platform.claude.com/docs/en/api/overview
+```
+
+Then fetch each individual endpoint page to collect the full schema (request
+body, path params, query params, response fields). Run all fetches in parallel.
+
+For each endpoint, identify:
+- HTTP method + path
+- Required and optional request fields with types
+- Response fields with types
+- Whether it maps to a **resource** (Create/Read/Delete or CRUD) or a
+  **data source** (Read-only lookup or list)
+
+Mapping heuristic:
+- `POST` + `GET /{id}` + `DELETE /{id}` → **resource** (ForceNew if no PATCH/PUT)
+- `POST` + `GET /{id}` + `PATCH /{id}` + `DELETE /{id}` → **resource** (with Update)
+- `GET /{id}` only → **data source** (single lookup)
+- `GET /` (list) → **data source** (list)
+
+Also check the Go SDK for existing types:
+```bash
+find $(go env GOPATH)/pkg/mod/github.com/anthropics/anthropic-sdk-go* -name "beta*.go" | xargs grep -l "<Resource>"
+```
+
+### Step 2 — Plan subtasks
+
+Create one subtask per resource/data source. Each subtask must include:
+
+1. **API spec** — endpoint, SDK method signatures, request/response fields
+2. **Terraform schema** — attribute table with types and R/W annotations
+3. **Files to create/modify** — Go source, test file, example, template, native test
+4. **Go acceptance tests** — list of `TestAcc*` function names with what they verify
+5. **Terraform native test** — `.tftest.hcl` snippet with `parallel = true` and assert blocks
+
+**Do NOT create a separate subtask for tests.** Tests are part of every subtask.
+
+### Step 3 — Create Vibe Kanban subtasks
+
+Use `mcp__vibe_kanban__create_issue` for each subtask as a child of the current
+issue. Set `parent_issue_id` to the current issue's ID from `mcp__vibe_kanban__get_context`.
+
+Run all `create_issue` calls in a **single parallel message**.
+
+Priority guidelines:
+- Resources: `high`
+- Data sources: `medium`
+
+### Step 4 — Create GitHub issues and branches
+
+For each subtask, in a **single parallel message**:
+- `mcp__github__issue_write` (method: `create`) — mirror the Kanban description as a GitHub issue
+- `mcp__github__create_branch` (from `main`) — one branch per subtask
+
+Branch naming convention:
+- `anthropic_skill` resource → `feat/skill-resource`
+- `anthropic_skills` data source → `feat/skills-data-source`
+- `anthropic_skill_version` resource → `feat/skill-version-resource`
+- `anthropic_skill_versions` data source → `feat/skill-versions-data-source`
+
+### Step 5 — Cross-link everything
+
+Update each Vibe Kanban subtask description to add at the top:
+
+```
+GitHub Issue: https://github.com/ippontech/terraform-provider-anthropic/issues/<N>
+Branch: feat/<name>
+```
+
+Run all `mcp__vibe_kanban__update_issue` calls in a **single parallel message**.
+
+### Step 6 — Note on PRs
+
+GitHub requires at least one commit before a PR can be opened. Always inform the user:
+
+> "Branches are created and ready. Open a draft PR on each branch once the first commit is pushed."
+
+## Implementation guidance
+
+Each subtask description should reference:
+- **Skill for implementation**: `ippon-cd-terraform-provider` — follow its conventions
+  for schema definition, CRUD methods, ForceNew attributes, nested objects, examples,
+  templates (with non-empty `subcategory`), and Terraform native tests.
+- **Subagent for review**: after implementation is complete on a branch, launch the
+  `terraform-provider-code-reviewer` subagent pointing at the changed files.
+
+## Parallelization rules
+
+| Step | Strategy |
+|---|---|
+| Fetch API docs pages | One `WebFetch` per page in a single message |
+| Create Vibe Kanban subtasks | One `create_issue` per subtask in a single message |
+| Create GitHub issues + branches | All `issue_write` + `create_branch` calls in a single message |
+| Update Kanban subtasks with links | One `update_issue` per subtask in a single message |
+| Implementation | All subtasks are independent — can be parallelized across agents |
+
+## Subtask description template
+
+```markdown
+GitHub Issue: <url>
+
+<One-line summary of what this implements.>
+
+## Branch
+`<branch-name>` (open PR once first commit is pushed)
+
+## API
+- `METHOD /v1/<path>` — description
+
+## SDK methods (anthropic-sdk-go)
+- `client.Beta.<Service>.<Method>(ctx, params)` → `ResponseType`
+
+## Terraform schema
+| Attribute | Type | R/W |
+|---|---|---|
+| `id` | string | Computed |
+| `...` | ... | ... |
+
+## Files to create / modify
+- `internal/provider/<name>_resource.go`
+- `internal/provider/<name>_resource_test.go` — Go acceptance tests
+- `internal/provider/provider.go` — register factory function
+- `examples/resources/<name>/resource.tf` — expose relevant outputs
+- `templates/resources/<name>.md.tmpl` — subcategory: "<Category>"
+- `tests/<name>.tftest.hcl` — Terraform native test
+
+## Go acceptance tests
+- `TestAcc<Name>Resource_basic` — create with minimal config, check `id` is set
+- `testAccCheck<Name>Destroyed` — destroy checker
+- ImportState round-trip step
+
+## Terraform native test (`tests/<name>.tftest.hcl`)
+```hcl
+run "<name>_resource_creates_<name>" {
+  parallel = true
+  module { source = "./examples/resources/<name>" }
+  assert {
+    condition     = output.<name>_id != ""
+    error_message = "Expected <name>_id to be non-empty."
+  }
+}
+```
+
+Run `make` after implementation, then `make terraform-test`.
+```
+
+## Example invocation
+
+User: "I'd like to implement /v1/environments APIs"
+
+1. Fetch `https://platform.claude.com/docs/en/api/overview` + all Environments endpoint pages in parallel
+2. Identify: `anthropic_environment` resource + `anthropic_environment` data source + `anthropic_environments` data source
+3. Create 3 Kanban subtasks in parallel (all `create_issue` in one message)
+4. Create 3 GitHub issues + 3 branches in parallel (all in one message)
+5. Update 3 Kanban subtasks with links in parallel (all `update_issue` in one message)
+6. Report summary table to the user and remind them to open draft PRs after first commits

--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Automates planning and scaffolding for implementing Anthropic API endpoints
   as Terraform resources and data sources. Use when starting work on a new API
   (e.g. /v1/skills, /v1/environments) to generate fully cross-linked Vibe Kanban
-  subtasks, GitHub issues, and branches — one per resource/data source — ready
+  issues, GitHub issues, and branches — one per resource/data source — ready
   for parallel implementation.
 model: sonnet
 ---
@@ -19,7 +19,7 @@ Anthropic API as Terraform resources and data sources in this provider.
 The user says something like:
 - "I'd like to implement /v1/environments APIs"
 - "Plan the work for the Files API"
-- "Create subtasks for the Sessions endpoints"
+- "Create issues for the Sessions endpoints"
 
 ## Workflow
 
@@ -52,9 +52,9 @@ Also check the Go SDK for existing types:
 find $(go env GOPATH)/pkg/mod/github.com/anthropics/anthropic-sdk-go* -name "beta*.go" | xargs grep -l "<Resource>"
 ```
 
-### Step 2 — Plan subtasks
+### Step 2 — Plan issues
 
-Create one subtask per resource/data source. Each subtask must include:
+Create one issue per resource/data source. Each issue must include:
 
 1. **API spec** — endpoint, SDK method signatures, request/response fields
 2. **Terraform schema** — attribute table with types and R/W annotations
@@ -62,12 +62,13 @@ Create one subtask per resource/data source. Each subtask must include:
 4. **Go acceptance tests** — list of `TestAcc*` function names with what they verify
 5. **Terraform native test** — `.tftest.hcl` snippet with `parallel = true` and assert blocks
 
-**Do NOT create a separate subtask for tests.** Tests are part of every subtask.
+**Do NOT create a separate issue for tests.** Tests are part of every issue.
 
-### Step 3 — Create Vibe Kanban subtasks
+### Step 3 — Create Vibe Kanban issues
 
-Use `mcp__vibe_kanban__create_issue` for each subtask as a child of the current
-issue. Set `parent_issue_id` to the current issue's ID from `mcp__vibe_kanban__get_context`.
+Use `mcp__vibe_kanban__create_issue` for each resource/data source as a
+top-level issue (no `parent_issue_id`). Top-level issues are visible on the
+kanban board; subtasks are not.
 
 Run all `create_issue` calls in a **single parallel message**.
 
@@ -89,7 +90,7 @@ Branch naming convention:
 
 ### Step 5 — Cross-link everything
 
-Update each Vibe Kanban subtask description to add at the top:
+Update each Vibe Kanban issue description to add at the top:
 
 ```
 GitHub Issue: https://github.com/ippontech/terraform-provider-anthropic/issues/<N>
@@ -118,10 +119,10 @@ Each subtask description should reference:
 | Step | Strategy |
 |---|---|
 | Fetch API docs pages | One `WebFetch` per page in a single message |
-| Create Vibe Kanban subtasks | One `create_issue` per subtask in a single message |
+| Create Vibe Kanban issues | One `create_issue` per issue in a single message |
 | Create GitHub issues + branches | All `issue_write` + `create_branch` calls in a single message |
-| Update Kanban subtasks with links | One `update_issue` per subtask in a single message |
-| Implementation | All subtasks are independent — can be parallelized across agents |
+| Update Kanban issues with links | One `update_issue` per issue in a single message |
+| Implementation | All issues are independent — can be parallelized across agents |
 
 ## Subtask description template
 
@@ -179,7 +180,7 @@ User: "I'd like to implement /v1/environments APIs"
 
 1. Fetch `https://platform.claude.com/docs/en/api/overview` + all Environments endpoint pages in parallel
 2. Identify: `anthropic_environment` resource + `anthropic_environment` data source + `anthropic_environments` data source
-3. Create 3 Kanban subtasks in parallel (all `create_issue` in one message)
+3. Create 3 Kanban issues in parallel (all `create_issue` in one message, no `parent_issue_id`)
 4. Create 3 GitHub issues + 3 branches in parallel (all in one message)
-5. Update 3 Kanban subtasks with links in parallel (all `update_issue` in one message)
+5. Update 3 Kanban issues with links in parallel (all `update_issue` in one message)
 6. Report summary table to the user and remind them to open draft PRs after first commits


### PR DESCRIPTION
## Summary

Adds `.claude/skills/vibe-kanban-brainstorming/SKILL.md` — a Claude skill that automates the planning and scaffolding workflow when implementing a new Anthropic API in this Terraform provider.

Closes #38 (TAU-10)

## What the skill does

Given a target API (e.g. `/v1/environments`), the skill guides Claude to:

1. Fetch all endpoint pages in parallel and identify resources vs. data sources
2. Plan one issue per resource/data source (tests included — no standalone issue)
3. Create one top-level Vibe Kanban issue per resource/data source in a single parallel message (top-level so they appear on the board)
4. Create Vibe Kanban relationships between dependent issues (`blocking` or `related`) in a single parallel message
5. Create one GitHub issue + one branch per Kanban issue, all in a single parallel message
6. Cross-link Kanban issues ↔ GitHub issues ↔ branches in a single parallel message
7. Remind the user to open draft PRs once first commits are pushed

## Key principles encoded

- Top-level Vibe Kanban issues (not subtasks) so they are visible on the kanban board
- Issue relationships wired up via `create_issue_relationship` (`blocking` when one must merge first, `related` for resource↔data source and single↔list data source pairs)
- `ippon-cd-terraform-provider` skill for implementation guidance
- `terraform-provider-code-reviewer` subagent for review after each PR
- Maximum parallelism: each group of independent operations runs in one message

🤖 Generated with [Claude Code](https://claude.com/claude-code)