### PR TITLE
chore: add update-pr-description skill with Stop hook auto-trigger

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -n \"$branch\" ] && [ \"$branch\" != \"main\" ] && [ \"$branch\" != \"HEAD\" ] && gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,11 @@
       }
     ]
   },
+  "permissions": {
+    "allow": [
+      "Bash(touch /tmp/claude-pr-desc-done-*)"
+    ]
+  },
   "enabledPlugins": {
     "terraform-skill@antonbabenko": true,
     "terraform@claude-plugins-official": true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -n \"$branch\" ] && [ \"$branch\" != \"main\" ] && [ \"$branch\" != \"HEAD\" ] && gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
+            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 60 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
             "timeout": 15
           }
         ]

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -70,3 +70,10 @@ Guidelines:
 
 Call `mcp__github__update_pull_request` with the new `body` and report the PR
 URL back to the user.
+
+Then write the sentinel file to suppress the Stop hook for 60 seconds:
+
+```bash
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+touch "/tmp/claude-pr-desc-done-$(echo "$branch" | tr '/' '-')"
+```

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: update-pr-description
+description: >
+  Updates the GitHub PR description for the current branch based on the work
+  done in the current Claude session. Use after any meaningful change to a PR
+  (feature, fix, refactor, docs). Invoked automatically when Claude stops if
+  an open PR exists for the current branch.
+model: sonnet
+---
+
+# update-pr-description
+
+Use this skill to rewrite the PR description so it accurately reflects what
+was implemented during this session.
+
+## Trigger
+
+- Automatically at the end of any session where an open PR exists for the
+  current branch
+- Explicitly when the user says "update the PR description" or similar
+
+## Workflow
+
+### Step 1 — Gather context
+
+Run in a **single parallel message**:
+
+```bash
+git rev-parse --abbrev-ref HEAD      # current branch
+git log main..HEAD --oneline         # commits on this branch
+git diff main...HEAD --stat          # files changed vs main
+```
+
+### Step 2 — Find the open PR
+
+Use `mcp__github__pull_request_read` (method: `get`) with the current branch
+name to retrieve the PR number and existing description.
+
+If no open PR exists for this branch, stop silently.
+
+### Step 3 — Write the updated description
+
+Synthesise the new body from two sources:
+1. **Session context** — what was actually discussed and changed during this
+   Claude session (the primary source of truth)
+2. **Git context** — commit messages and changed files for completeness
+
+Use this structure:
+
+```markdown
+## Summary
+
+<1-3 bullet points: what changed and why — lead with the why>
+
+## What changed
+
+<Optional: additional detail if the summary bullets are not sufficient.
+ Omit this section if the summary covers everything.>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Guidelines:
+- Preserve any existing "Closes #N" or issue references from the old description
+- One bullet per logical change — do not list individual files
+- Do not invent claims about behaviour you have not observed in this session
+- Keep it concise: a reviewer should understand the PR in under 30 seconds
+
+### Step 4 — Update the PR
+
+Call `mcp__github__update_pull_request` with the new `body` and report the PR
+URL back to the user.


### PR DESCRIPTION
## Summary

- Adds `/update-pr-description` slash command that rewrites the GitHub PR description from the current Claude session's context, so PR bodies stay accurate after iterative changes without manual effort
- Wires a `Stop` hook that automatically detects an open PR on the current branch and triggers the skill before Claude finishes
- Prevents double-triggering: the skill writes a sentinel file after updating the PR; the hook skips for 60 seconds if the sentinel is fresh, and `Bash(touch /tmp/claude-pr-desc-done-*)` is allow-listed so the write never prompts for permission

## What changed

- `.claude/skills/update-pr-description/SKILL.md` — skill definition: gather git context, find the open PR, synthesise a description from session context + commits, call `mcp__github__update_pull_request`, then touch the sentinel file
- `.claude/settings.json` — `Stop` hook with sentinel freshness check; sentinel `touch` added to the Bash allow list

🤖 Generated with [Claude Code](https://claude.com/claude-code)