### PR TITLE
chore: rename skills to drop ippon-cd- prefix

### DIFF
--- a/.claude/agents/terraform-provider-code-reviewer.md
+++ b/.claude/agents/terraform-provider-code-reviewer.md
@@ -34,7 +34,7 @@ You review **recently changed or added files** unless explicitly asked to review
 
 ## GitHub Actions Workflow Review Checklist
 
-### ippon-cd-cicd Security Skill Compliance
+### cicd Security Skill Compliance
 Apply the following security checks rigorously to prevent supply chain attacks and credential leaks:
 
 **Action Pinning (Supply Chain)**

--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ippon-cd-cicd
+name: cicd
 description: Maintains CICD pipeline templates, workflows or pipelines. Use when working with GitLab/GitHub Actions CICD tools.
 model: sonnet
 ---
@@ -15,4 +15,4 @@ model: sonnet
 
 # GitHub Actions
 
-For GitHub Actions workflows, apply the `ippon-cd-github-actions` skill.
+For GitHub Actions workflows, apply the `github-actions` skill.

--- a/.claude/skills/github-actions/SKILL.md
+++ b/.claude/skills/github-actions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ippon-cd-github-actions
+name: github-actions
 description: GitHub Actions best practices for writing and reviewing workflows. Use when creating or modifying .github/workflows/ files.
 model: sonnet
 ---

--- a/.claude/skills/install-tools/SKILL.md
+++ b/.claude/skills/install-tools/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ippon-cd-install-tools
+name: install-tools
 description: Installs tools on your environment such as java, npm, node, terraform, go,. Use when installing a new tool, updating an existing one or uninstalling one.
 model: sonnet
 ---

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ippon-cd-security
+name: security
 description: Security best practices for Claude Code configuration and CI/CD pipelines. Use when reviewing or modifying Claude settings, permissions, secrets handling, or security-sensitive configuration.
 model: sonnet
 ---

--- a/.claude/skills/terraform-provider/SKILL.md
+++ b/.claude/skills/terraform-provider/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ippon-cd-terraform-provider
+name: terraform-provider
 description: Develops Terraform providers in Go. Use when creating a new Terraform provider or updating an existing one.
 model: sonnet
 ---

--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -123,7 +123,7 @@ GitHub requires at least one commit before a PR can be opened. Always inform the
 ## Implementation guidance
 
 Each subtask description should reference:
-- **Skill for implementation**: `ippon-cd-terraform-provider` — follow its conventions
+- **Skill for implementation**: `terraform-provider` — follow its conventions
   for schema definition, CRUD methods, ForceNew attributes, nested objects, examples,
   templates (with non-empty `subcategory`), and Terraform native tests.
 - **Subagent for review**: after implementation is complete on a branch, launch the


### PR DESCRIPTION
## Summary

- Drop the `ippon-cd-` prefix from all five Claude Code skills so they are invoked as `/security`, `/github-actions`, `/terraform-provider`, `/cicd`, and `/install-tools`
- Update the `name:` frontmatter in each `SKILL.md` to match the new directory name
- Update cross-references to the old skill names in `cicd/SKILL.md`, `vibe-kanban-brainstorming/SKILL.md`, and the `terraform-provider-code-reviewer` agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)