### PR TITLE
chore: add invariants to vibe-kanban-brainstorming skill

### DIFF
--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -120,6 +120,35 @@ GitHub requires at least one commit before a PR can be opened. Always inform the
 
 > "Branches are created and ready. Open a draft PR on each branch once the first commit is pushed."
 
+## Invariants (never violate)
+
+### One GitHub issue per Vibe Kanban ticket
+Every Vibe Kanban issue **must** have exactly one corresponding GitHub issue. The
+GitHub issue URL must be written back into the Vibe Kanban issue description (Step 6).
+The two systems are mirrors: Vibe Kanban is local/private, GitHub is shared.
+
+### One PR per ticket — no bundled PRs
+Each Vibe Kanban ticket must result in **exactly one dedicated PR**. Never batch
+multiple tickets into one PR, even if the changes seem small or related. Reviewers
+need one PR per logical unit.
+
+### Vibe Kanban ticket numbers must not appear outside Vibe Kanban
+`TAU-N` identifiers are local to Vibe Kanban and meaningless on GitHub.
+**Never** include them in:
+- Commit messages
+- PR titles
+- PR descriptions
+
+Use the GitHub issue number (`#N`) or a plain description instead.
+
+### Branch isolation during parallel implementation
+When implementing tickets in parallel via agents, each agent must only commit
+changes that belong to its own ticket onto its own branch. An agent must never:
+- Check out or modify files on a sibling branch
+- Leave untracked files in the main worktree that belong to a different ticket
+
+Use `EnterWorktree` / isolated worktrees to enforce this boundary.
+
 ## Implementation guidance
 
 Each subtask description should reference:

--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -133,7 +133,7 @@ multiple tickets into one PR, even if the changes seem small or related. Reviewe
 need one PR per logical unit.
 
 ### Vibe Kanban ticket numbers must not appear outside Vibe Kanban
-`TAU-N` identifiers are local to Vibe Kanban and meaningless on GitHub.
+Vibe Kanban ticket identifiers (e.g. `TAU-N`, `ABC-N` — the prefix varies per installation) are local to Vibe Kanban and meaningless on GitHub.
 **Never** include them in:
 - Commit messages
 - PR titles


### PR DESCRIPTION
## Summary

- Documents four invariants learned from the skills API implementation session to prevent recurring mistakes
- Each Vibe Kanban ticket must map to exactly one GitHub issue and one dedicated PR (no bundled PRs)
- Vibe Kanban ticket identifiers (prefix varies per installation) must never appear in commit messages, PR titles, or descriptions — use `#N` GitHub issue references instead
- Parallel agents must use isolated worktrees and never leave untracked files on sibling branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)