### PR TITLE
fix: add YAML frontmatter to SKILL.md example and test files

### DIFF
--- a/examples/data-sources/skill/SKILL.md
+++ b/examples/data-sources/skill/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill
+description: An example custom skill.
+---
+
 # Example Skill
 
 An example custom skill.

--- a/examples/data-sources/skill_version/SKILL.md
+++ b/examples/data-sources/skill_version/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill-version
+description: An example custom skill version for demonstration.
+---
+
 # Example Skill Version
 
 An example custom skill version for demonstration.

--- a/examples/data-sources/skill_versions/SKILL.md
+++ b/examples/data-sources/skill_versions/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill-version
+description: An example custom skill version for demonstration.
+---
+
 # Example Skill Version
 
 An example custom skill version for demonstration.

--- a/examples/data-sources/skills/SKILL.md
+++ b/examples/data-sources/skills/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill
+description: An example custom skill.
+---
+
 # Example Skill
 
 An example custom skill.

--- a/examples/resources/skill/SKILL.md
+++ b/examples/resources/skill/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill
+description: An example custom skill.
+---
+
 # Example Skill
 
 An example custom skill.

--- a/examples/resources/skill_version/SKILL.md
+++ b/examples/resources/skill_version/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: example-skill-version
+description: An example custom skill version for demonstration.
+---
+
 # Example Skill Version
 
 An example custom skill version for demonstration.

--- a/internal/provider/skill_resource_test.go
+++ b/internal/provider/skill_resource_test.go
@@ -20,7 +20,7 @@ func testAccSkillFilePath(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "SKILL.md")
-	if err := os.WriteFile(p, []byte("# Test Skill\n\nFor testing.\n"), 0644); err != nil {
+	if err := os.WriteFile(p, []byte("---\nname: test-skill\ndescription: For testing.\n---\n\n# Test Skill\n\nFor testing.\n"), 0644); err != nil {
 		t.Fatalf("failed to write test skill file: %s", err)
 	}
 	return p


### PR DESCRIPTION
## Summary

- The Anthropic API now requires `SKILL.md` to start with a YAML frontmatter block (`---`); without it, skill creation returns a 400 error causing all skill-related tests to fail
- Added `name` and `description` frontmatter to all 6 `SKILL.md` files under `examples/` (resources and data sources)
- Updated the acceptance test helper in `skill_resource_test.go` to write valid frontmatter into the temporary `SKILL.md` it creates

🤖 Generated with [Claude Code](https://claude.com/claude-code)