### PR TITLE
fix: align SKILL.md name field with parent directory name

### DIFF
--- a/examples/data-sources/skill/SKILL.md
+++ b/examples/data-sources/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill
+name: skill
 description: An example custom skill.
 ---
 

--- a/examples/data-sources/skill_version/SKILL.md
+++ b/examples/data-sources/skill_version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill-version
+name: skill_version
 description: An example custom skill version for demonstration.
 ---
 

--- a/examples/data-sources/skill_versions/SKILL.md
+++ b/examples/data-sources/skill_versions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill-version
+name: skill_versions
 description: An example custom skill version for demonstration.
 ---
 

--- a/examples/data-sources/skills/SKILL.md
+++ b/examples/data-sources/skills/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill
+name: skills
 description: An example custom skill.
 ---
 

--- a/examples/resources/skill/SKILL.md
+++ b/examples/resources/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill
+name: skill
 description: An example custom skill.
 ---
 

--- a/examples/resources/skill_version/SKILL.md
+++ b/examples/resources/skill_version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: example-skill-version
+name: skill_version
 description: An example custom skill version for demonstration.
 ---
 

--- a/internal/provider/skill_resource_test.go
+++ b/internal/provider/skill_resource_test.go
@@ -18,7 +18,13 @@ import (
 
 func testAccSkillFilePath(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	// The API requires the multipart folder name to match the `name` field in
+	// the SKILL.md frontmatter. Create an explicit subdirectory so dirName is
+	// predictable rather than relying on t.TempDir()'s random suffix.
+	dir := filepath.Join(t.TempDir(), "test-skill")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create test skill directory: %s", err)
+	}
 	p := filepath.Join(dir, "SKILL.md")
 	if err := os.WriteFile(p, []byte("---\nname: test-skill\ndescription: For testing.\n---\n\n# Test Skill\n\nFor testing.\n"), 0644); err != nil {
 		t.Fatalf("failed to write test skill file: %s", err)


### PR DESCRIPTION
## Summary

- The Anthropic API validates that the multipart folder name matches the `name` field in the `SKILL.md` frontmatter; a mismatch returns a 400 error like `"The folder name 'X' must match the skill name 'Y' in SKILL.md"`
- Updated all 6 example `SKILL.md` files to use their containing directory name as the `name` value (e.g., `skill`, `skill_version`, `skill_versions`, `skills`)
- Updated the acceptance test helper to create an explicit `test-skill/` subdirectory so the multipart folder name is predictable rather than inheriting `t.TempDir()`'s random suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)