### PR TITLE
fix: delete skill versions before deleting skill, fix import state

### DIFF
--- a/docs/data-sources/skill.md
+++ b/docs/data-sources/skill.md
@@ -26,6 +26,7 @@ terraform {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill (data source)"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 data "anthropic_skill" "example" {

--- a/docs/data-sources/skill_version.md
+++ b/docs/data-sources/skill_version.md
@@ -24,7 +24,8 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/docs/data-sources/skill_versions.md
+++ b/docs/data-sources/skill_versions.md
@@ -25,7 +25,8 @@ terraform {
 
 # Create a skill and a version so the list is guaranteed non-empty for tests.
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/docs/data-sources/skills.md
+++ b/docs/data-sources/skills.md
@@ -32,6 +32,7 @@ variable "source_filter" {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill (list)"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 data "anthropic_skills" "all" {

--- a/docs/resources/skill.md
+++ b/docs/resources/skill.md
@@ -26,6 +26,7 @@ terraform {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 output "skill_id" {
@@ -47,6 +48,7 @@ output "skill_source" {
 ### Optional
 
 - `display_title` (String) Human-readable display title for the skill. Not included in the prompt sent to the model.
+- `force_destroy` (Boolean) When `true`, all skill versions are deleted before the skill is destroyed, allowing Terraform to remove a skill that still has versions. Defaults to `false`. Set to `true` only if you intend for all versions to be permanently deleted.
 
 ### Read-Only
 

--- a/docs/resources/skill.md
+++ b/docs/resources/skill.md
@@ -50,6 +50,8 @@ output "skill_source" {
 - `display_title` (String) Human-readable display title for the skill. Not included in the prompt sent to the model.
 - `force_destroy` (Boolean) When `true`, all skill versions are deleted before the skill is destroyed, allowing Terraform to remove a skill that still has versions. Defaults to `false`. Set to `true` only if you intend for all versions to be permanently deleted.
 
+~> **Note:** This only deletes versions when the skill is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the skill or destroying the skill, this flag will not work. Additionally, when importing a skill, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
+
 ### Read-Only
 
 - `created_at` (String) ISO 8601 timestamp of when the skill was created.

--- a/docs/resources/skill_version.md
+++ b/docs/resources/skill_version.md
@@ -24,7 +24,8 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/examples/data-sources/skill/data_source.tf
+++ b/examples/data-sources/skill/data_source.tf
@@ -12,6 +12,7 @@ terraform {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill (data source)"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 data "anthropic_skill" "example" {

--- a/examples/data-sources/skill_version/data_source.tf
+++ b/examples/data-sources/skill_version/data_source.tf
@@ -10,7 +10,8 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/examples/data-sources/skill_versions/data_source.tf
+++ b/examples/data-sources/skill_versions/data_source.tf
@@ -11,7 +11,8 @@ terraform {
 
 # Create a skill and a version so the list is guaranteed non-empty for tests.
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/examples/data-sources/skills/data_source.tf
+++ b/examples/data-sources/skills/data_source.tf
@@ -18,6 +18,7 @@ variable "source_filter" {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill (list)"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 data "anthropic_skills" "all" {

--- a/examples/resources/skill/resource.tf
+++ b/examples/resources/skill/resource.tf
@@ -12,6 +12,7 @@ terraform {
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
   files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 output "skill_id" {

--- a/examples/resources/skill_version/resource.tf
+++ b/examples/resources/skill_version/resource.tf
@@ -10,7 +10,8 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files = ["${path.module}/SKILL.md"]
+  files         = ["${path.module}/SKILL.md"]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {

--- a/internal/provider/skill_data_source_test.go
+++ b/internal/provider/skill_data_source_test.go
@@ -33,7 +33,8 @@ func TestAccSkillDataSource_basic(t *testing.T) {
 
 const testAccSkillDataSourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 data "anthropic_skill" "test" {
   skill_id = anthropic_skill.test.id

--- a/internal/provider/skill_resource.go
+++ b/internal/provider/skill_resource.go
@@ -213,7 +213,28 @@ func (r *SkillResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	_, err := r.client.Beta.Skills.Delete(ctx, data.ID.ValueString(), anthropic.BetaSkillDeleteParams{})
+	skillID := data.ID.ValueString()
+
+	// The API requires all versions to be deleted before the skill itself can be deleted.
+	iter := r.client.Beta.Skills.Versions.ListAutoPaging(ctx, skillID, anthropic.BetaSkillVersionListParams{})
+	for iter.Next() {
+		v := iter.Current()
+		_, err := r.client.Beta.Skills.Versions.Delete(ctx, v.Version, anthropic.BetaSkillVersionDeleteParams{SkillID: skillID})
+		if err != nil {
+			var apierr *anthropic.Error
+			if errors.As(err, &apierr) && apierr.StatusCode == 404 {
+				continue
+			}
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete skill version %s: %s", v.Version, err))
+			return
+		}
+	}
+	if err := iter.Err(); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list skill versions for deletion: %s", err))
+		return
+	}
+
+	_, err := r.client.Beta.Skills.Delete(ctx, skillID, anthropic.BetaSkillDeleteParams{})
 	if err != nil {
 		var apierr *anthropic.Error
 		if errors.As(err, &apierr) && apierr.StatusCode == 404 {
@@ -253,15 +274,19 @@ func mapSkillNewResponseToState(skill *anthropic.BetaSkillNewResponse, data *Ski
 }
 
 func mapSkillGetResponseToState(skill *anthropic.BetaSkillGetResponse, data *SkillResourceModel) {
+	// Detect import context: during a fresh import the state has only the ID,
+	// so created_at is null. We use this to decide whether to always populate
+	// display_title from the API (import) or only when the user has it configured
+	// (normal read — to avoid unintended plan drift).
+	isImport := data.CreatedAt.IsNull()
+
 	data.ID = types.StringValue(skill.ID)
 	data.CreatedAt = types.StringValue(skill.CreatedAt)
 	data.UpdatedAt = types.StringValue(skill.UpdatedAt)
 	data.LatestVersion = types.StringValue(skill.LatestVersion)
 	data.Source = types.StringValue(skill.Source)
 
-	// Only adopt display_title from the API if the user explicitly set it in config;
-	// otherwise leave the plan/state value (null) to avoid drift on subsequent plans.
-	if !data.DisplayTitle.IsNull() {
+	if !data.DisplayTitle.IsNull() || isImport {
 		if skill.DisplayTitle != "" {
 			data.DisplayTitle = types.StringValue(skill.DisplayTitle)
 		} else {

--- a/internal/provider/skill_resource.go
+++ b/internal/provider/skill_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -52,6 +53,7 @@ type SkillResourceModel struct {
 	ID            types.String `tfsdk:"id"`
 	DisplayTitle  types.String `tfsdk:"display_title"`
 	Files         types.List   `tfsdk:"files"`
+	ForceDestroy  types.Bool   `tfsdk:"force_destroy"`
 	CreatedAt     types.String `tfsdk:"created_at"`
 	UpdatedAt     types.String `tfsdk:"updated_at"`
 	LatestVersion types.String `tfsdk:"latest_version"`
@@ -83,6 +85,14 @@ func (r *SkillResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				MarkdownDescription: "Local file paths to upload for the skill. Must include a `SKILL.md` file at the root of the directory.",
 				PlanModifiers:       []planmodifier.List{listplanmodifier.RequiresReplace()},
 				Validators:          []validator.List{listvalidator.SizeAtLeast(1)},
+			},
+			"force_destroy": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				MarkdownDescription: "When `true`, all skill versions are deleted before the skill is destroyed, " +
+					"allowing Terraform to remove a skill that still has versions. " +
+					"Defaults to `false`. Set to `true` only if you intend for all versions to be permanently deleted.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -216,22 +226,26 @@ func (r *SkillResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	skillID := data.ID.ValueString()
 
 	// The API requires all versions to be deleted before the skill itself can be deleted.
-	iter := r.client.Beta.Skills.Versions.ListAutoPaging(ctx, skillID, anthropic.BetaSkillVersionListParams{})
-	for iter.Next() {
-		v := iter.Current()
-		_, err := r.client.Beta.Skills.Versions.Delete(ctx, v.Version, anthropic.BetaSkillVersionDeleteParams{SkillID: skillID})
-		if err != nil {
-			var apierr *anthropic.Error
-			if errors.As(err, &apierr) && apierr.StatusCode == 404 {
-				continue
+	// Only do this when force_destroy = true; otherwise surface the API error so the
+	// user is aware that versions exist and must be removed explicitly.
+	if data.ForceDestroy.ValueBool() {
+		iter := r.client.Beta.Skills.Versions.ListAutoPaging(ctx, skillID, anthropic.BetaSkillVersionListParams{})
+		for iter.Next() {
+			v := iter.Current()
+			_, err := r.client.Beta.Skills.Versions.Delete(ctx, v.Version, anthropic.BetaSkillVersionDeleteParams{SkillID: skillID})
+			if err != nil {
+				var apierr *anthropic.Error
+				if errors.As(err, &apierr) && apierr.StatusCode == 404 {
+					continue
+				}
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete skill version %s: %s", v.Version, err))
+				return
 			}
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete skill version %s: %s", v.Version, err))
+		}
+		if err := iter.Err(); err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list skill versions for deletion: %s", err))
 			return
 		}
-	}
-	if err := iter.Err(); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list skill versions for deletion: %s", err))
-		return
 	}
 
 	_, err := r.client.Beta.Skills.Delete(ctx, skillID, anthropic.BetaSkillDeleteParams{})

--- a/internal/provider/skill_resource.go
+++ b/internal/provider/skill_resource.go
@@ -92,7 +92,13 @@ func (r *SkillResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Default:  booldefault.StaticBool(false),
 				MarkdownDescription: "When `true`, all skill versions are deleted before the skill is destroyed, " +
 					"allowing Terraform to remove a skill that still has versions. " +
-					"Defaults to `false`. Set to `true` only if you intend for all versions to be permanently deleted.",
+					"Defaults to `false`. Set to `true` only if you intend for all versions to be permanently deleted.\n\n" +
+					"~> **Note:** This only deletes versions when the skill is destroyed, not when setting this parameter to `true`. " +
+					"Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required " +
+					"to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, " +
+					"this flag will have no effect. If setting this field in the same operation that would require replacing the skill " +
+					"or destroying the skill, this flag will not work. Additionally, when importing a skill, a successful `terraform apply` " +
+					"is required to set this value in state before it will take effect on a destroy operation.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/skill_resource_test.go
+++ b/internal/provider/skill_resource_test.go
@@ -69,11 +69,12 @@ func TestAccSkillResource_basic(t *testing.T) {
 			},
 			// ImportState — display_title is not set in config, so the API may return a
 			// server-derived value that won't match after import.
+			// updated_at may differ between the create response and a subsequent GET.
 			{
 				ResourceName:            "anthropic_skill.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"files", "display_title"},
+				ImportStateVerifyIgnore: []string{"files", "display_title", "updated_at"},
 			},
 		},
 	})
@@ -96,12 +97,12 @@ func TestAccSkillResource_withDisplayTitle(t *testing.T) {
 					resource.TestCheckResourceAttr("anthropic_skill.test", "source", "custom"),
 				),
 			},
-			// ImportState
+			// ImportState — updated_at may differ between create response and a subsequent GET.
 			{
 				ResourceName:            "anthropic_skill.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"files"},
+				ImportStateVerifyIgnore: []string{"files", "updated_at"},
 			},
 		},
 	})

--- a/internal/provider/skill_resource_test.go
+++ b/internal/provider/skill_resource_test.go
@@ -67,14 +67,14 @@ func TestAccSkillResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("anthropic_skill.test", "latest_version"),
 				),
 			},
-			// ImportState — display_title is not set in config, so the API may return a
-			// server-derived value that won't match after import.
+			// ImportState — display_title is not set in config so the API may return a
+			// server-derived value; force_destroy is not tracked server-side;
 			// updated_at may differ between the create response and a subsequent GET.
 			{
 				ResourceName:            "anthropic_skill.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"files", "display_title", "updated_at"},
+				ImportStateVerifyIgnore: []string{"files", "display_title", "force_destroy", "updated_at"},
 			},
 		},
 	})
@@ -97,12 +97,13 @@ func TestAccSkillResource_withDisplayTitle(t *testing.T) {
 					resource.TestCheckResourceAttr("anthropic_skill.test", "source", "custom"),
 				),
 			},
-			// ImportState — updated_at may differ between create response and a subsequent GET.
+			// ImportState — force_destroy is not tracked server-side;
+			// updated_at may differ between create response and a subsequent GET.
 			{
 				ResourceName:            "anthropic_skill.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"files", "updated_at"},
+				ImportStateVerifyIgnore: []string{"files", "force_destroy", "updated_at"},
 			},
 		},
 	})
@@ -110,7 +111,8 @@ func TestAccSkillResource_withDisplayTitle(t *testing.T) {
 
 const testAccSkillResourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 `
 
@@ -118,5 +120,6 @@ const testAccSkillResourceWithDisplayTitleConfig = `
 resource "anthropic_skill" "test" {
   display_title = "tf-acc-test-skill"
   files         = [%q]
+  force_destroy = true
 }
 `

--- a/internal/provider/skill_version_data_source_test.go
+++ b/internal/provider/skill_version_data_source_test.go
@@ -39,7 +39,8 @@ func TestAccSkillVersionDataSource_basic(t *testing.T) {
 
 const testAccSkillVersionDataSourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 resource "anthropic_skill_version" "test" {
   skill_id = anthropic_skill.test.id

--- a/internal/provider/skill_version_resource_test.go
+++ b/internal/provider/skill_version_resource_test.go
@@ -90,7 +90,8 @@ func TestAccSkillVersionResource_basic(t *testing.T) {
 
 const testAccSkillVersionResourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 
 resource "anthropic_skill_version" "test" {

--- a/internal/provider/skill_version_resource_test.go
+++ b/internal/provider/skill_version_resource_test.go
@@ -18,9 +18,15 @@ import (
 
 func testAccSkillVersionFilePath(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	// The API requires the multipart folder name to match the `name` field in
+	// the SKILL.md frontmatter. Create an explicit subdirectory so dirName is
+	// predictable rather than relying on t.TempDir()'s random suffix.
+	dir := filepath.Join(t.TempDir(), "test-skill-version")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create test skill version directory: %s", err)
+	}
 	p := filepath.Join(dir, "SKILL.md")
-	if err := os.WriteFile(p, []byte("# Test Skill Version\n\nFor testing.\n"), 0644); err != nil {
+	if err := os.WriteFile(p, []byte("---\nname: test-skill-version\ndescription: For testing.\n---\n\n# Test Skill Version\n\nFor testing.\n"), 0644); err != nil {
 		t.Fatalf("failed to write test skill version file: %s", err)
 	}
 	return p

--- a/internal/provider/skill_versions_data_source_test.go
+++ b/internal/provider/skill_versions_data_source_test.go
@@ -33,7 +33,8 @@ func TestAccSkillVersionsDataSource_basic(t *testing.T) {
 
 const testAccSkillVersionsDataSourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 resource "anthropic_skill_version" "test" {
   skill_id = anthropic_skill.test.id

--- a/internal/provider/skills_data_source_test.go
+++ b/internal/provider/skills_data_source_test.go
@@ -47,7 +47,8 @@ func TestAccSkillsDataSource_sourceFilter(t *testing.T) {
 
 const testAccSkillsDataSourceBasicConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 data "anthropic_skills" "test" {
   depends_on = [anthropic_skill.test]
@@ -56,7 +57,8 @@ data "anthropic_skills" "test" {
 
 const testAccSkillsDataSourceWithFilterConfig = `
 resource "anthropic_skill" "test" {
-  files = [%q]
+  files         = [%q]
+  force_destroy = true
 }
 data "anthropic_skills" "filtered" {
   source_filter = "custom"


### PR DESCRIPTION
## Summary

- **Delete bug (root cause of most failures)**: The API requires all skill versions to be deleted before a skill can be deleted. Added an opt-in \`force_destroy\` boolean attribute (defaulting to \`false\`, matching AWS S3 pattern) that, when \`true\`, lists and deletes all versions before destroying the skill — preventing the \`"Cannot delete skill with existing versions"\` error that left dangling resources across test runs
- **Import state fixes**: \`mapSkillGetResponseToState\` now detects import context (via \`created_at\` being null) and always populates \`display_title\` from the API on import; \`updated_at\` added to \`ImportStateVerifyIgnore\` since it can legitimately differ between the create response and a subsequent GET
- **Skill version test helper**: \`testAccSkillVersionFilePath\` now creates an explicit \`test-skill-version/\` subdirectory with proper YAML frontmatter, fixing two API 400 errors from the random \`t.TempDir()\` suffix and missing frontmatter

## What changed

- \`force_destroy\` schema attribute added to \`anthropic_skill\` with \`booldefault.StaticBool(false)\` and documentation of the two-step limitation (must apply \`true\` before destroy, same as S3)
- \`Delete\` now gates version cascade deletion on \`force_destroy = true\` in state
- All example configs and test configs updated to set \`force_destroy = true\` so tests can clean up after themselves
- \`mapSkillGetResponseToState\`: detect import context, always set \`display_title\` on import
- \`ImportStateVerifyIgnore\` updated to include \`force_destroy\` and \`updated_at\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)