### PR TITLE
fix(environment): add plan modifiers to resolve acc test failures

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
+          "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
             "timeout": 15
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-          "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
+            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
             "timeout": 15
           }
         ]

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -3,7 +3,8 @@ name: ship
 description: >
   Creates a branch named from the work done, commits all changes with a
   detailed conventional-commit message, pushes to GitHub, and opens a PR
-  whose title and body come directly from the commit message.
+  (or updates the existing PR description if one already exists) whose
+  title and body come directly from the commit message.
 model: sonnet
 ---
 
@@ -63,17 +64,42 @@ EOF
 )"
 ```
 
-### Step 4 — Push and open a PR
+### Step 4 — Push and open or update the PR
 
-Push the branch, then create the PR. The PR title must be the commit title (first line, without the `Co-Authored-By` trailer). The PR body must be the commit body.
+Push the branch:
 
 ```bash
 git push -u origin <branch-name>
+```
 
+Then check whether an open PR already exists for this branch:
+
+```bash
+gh pr view --json number,url --jq '"\(.number) \(.url)"' 2>/dev/null
+```
+
+**If no open PR exists** — create one. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body:
+
+```bash
 gh pr create \
   --title "<commit title>" \
   --body "$(cat <<'EOF'
 <commit body>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR:
+
+```bash
+git log main..HEAD --format="%s%n%n%b"   # all commit titles + bodies
+
+gh pr edit <number> \
+  --title "<title reflecting all commits>" \
+  --body "$(cat <<'EOF'
+<consolidated summary of all changes>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -96,12 +96,15 @@ EOF
 ```bash
 git log main..HEAD --format="%s%n%n%b"   # all commit titles + bodies
 
+cat > /tmp/pr_body.txt << 'ENDBODY'
+<consolidated summary of all changes>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+ENDBODY
 gh api repos/{owner}/{repo}/pulls/<number> \
   --method PATCH \
   --field title="<title reflecting all commits>" \
-  --field body="<consolidated summary of all changes>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --field body="$(cat /tmp/pr_body.txt)" \
   --jq '.html_url'
 ```
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -91,19 +91,18 @@ EOF
 )"
 ```
 
-**If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR:
+**If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR via the GitHub API (`gh pr edit` can fail with a Projects classic deprecation error):
 
 ```bash
 git log main..HEAD --format="%s%n%n%b"   # all commit titles + bodies
 
-gh pr edit <number> \
-  --title "<title reflecting all commits>" \
-  --body "$(cat <<'EOF'
-<consolidated summary of all changes>
+gh api repos/{owner}/{repo}/pulls/<number> \
+  --method PATCH \
+  --field title="<title reflecting all commits>" \
+  --field body="<consolidated summary of all changes>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --jq '.html_url'
 ```
 
 Report the PR URL to the user.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -81,3 +81,10 @@ EOF
 ```
 
 Report the PR URL to the user.
+
+Then write the sentinel file to suppress the stop hook (which would otherwise ask you to run `/update-pr-description` on a PR whose description is already correct):
+
+```bash
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+touch "/tmp/claude-pr-desc-done-$(echo "$branch" | tr '/' '-')"
+```

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ship
+description: >
+  Creates a branch named from the work done, commits all changes with a
+  detailed conventional-commit message, pushes to GitHub, and opens a PR
+  whose title and body come directly from the commit message.
+model: sonnet
+---
+
+# ship
+
+Turn local changes into a PR-ready branch in four steps: branch → commit → push → PR.
+
+## Trigger
+
+- Explicitly when the user says "ship", "push this", "create a PR", or similar
+- When significant work is done on main or a scratch branch and needs to be wrapped into a PR
+
+## Workflow
+
+### Step 1 — Understand the changes
+
+Run in a **single parallel message**:
+
+```bash
+git status
+git diff HEAD
+git log main..HEAD --oneline
+```
+
+Read any changed files you haven't already seen in this session. The goal is to understand *what* changed and *why* well enough to write an accurate commit message.
+
+### Step 2 — Create a branch
+
+If already on a non-main/non-master branch, skip this step.
+
+Derive a branch name from the work:
+- Format: `<type>/<short-description>` (e.g. `fix/environment-updated-at-plan-modifier`)
+- All lowercase, kebab-case, under 50 characters
+- Use conventional commit types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`
+
+```bash
+git checkout -b <branch-name>
+```
+
+### Step 3 — Commit
+
+Stage all relevant changed files (be explicit — avoid `git add -A` if untracked files might be sensitive) and create a commit with a conventional commit message:
+
+- **Title** (line 1): `<type>(<optional scope>): <imperative summary>` — 72 characters max
+- **Blank line**
+- **Body**: explain *why* the change was made and what problem it solves; use bullets for multiple changes; 80-character line wrap
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <summary>
+
+<body>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Step 4 — Push and open a PR
+
+Push the branch, then create the PR. The PR title must be the commit title (first line, without the `Co-Authored-By` trailer). The PR body must be the commit body.
+
+```bash
+git push -u origin <branch-name>
+
+gh pr create \
+  --title "<commit title>" \
+  --body "$(cat <<'EOF'
+<commit body>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL to the user.

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -68,8 +68,17 @@ Guidelines:
 
 ### Step 4 — Update the PR
 
-Call `mcp__github__update_pull_request` with the new `body` and report the PR
-URL back to the user.
+Use the GitHub API to update the PR (`gh pr edit` can fail with a Projects
+classic deprecation error):
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number> \
+  --method PATCH \
+  --field body="<new body>" \
+  --jq '.html_url'
+```
+
+Report the PR URL back to the user.
 
 Then write the sentinel file to suppress the Stop hook for 5 minutes:
 

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -72,9 +72,12 @@ Use the GitHub API to update the PR (`gh pr edit` can fail with a Projects
 classic deprecation error):
 
 ```bash
+cat > /tmp/pr_body.txt << 'ENDBODY'
+<new body>
+ENDBODY
 gh api repos/{owner}/{repo}/pulls/<number> \
   --method PATCH \
-  --field body="<new body>" \
+  --field body="$(cat /tmp/pr_body.txt)" \
   --jq '.html_url'
 ```
 

--- a/.claude/skills/update-project-knowledge/SKILL.md
+++ b/.claude/skills/update-project-knowledge/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: update-project-knowledge
+description: >
+  Reviews the work just done and updates CLAUDE.md, agent memories, and
+  subagent MD files to reflect any new conventions, packages, resources, or
+  patterns discovered. Run after completing any significant implementation task.
+model: sonnet
+---
+
+# update-project-knowledge
+
+Keep CLAUDE.md and agent memories accurate after each implementation task.
+
+## Trigger
+
+- Proactively at the end of any session where significant code was written
+- Explicitly when the user says "update Claude config", "sync project knowledge", or similar
+
+## Workflow
+
+### Step 1 — Gather context
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git log origin/main..HEAD --oneline
+git diff origin/main..HEAD --name-only
+```
+
+Also read `CLAUDE.md` to know what is already documented.
+
+### Step 2 — Identify gaps
+
+Cross-reference changed files against CLAUDE.md. Check each category:
+
+| If this changed | Check this in CLAUDE.md |
+|---|---|
+| New `*_resource.go` or `*_data_source.go` | "Implemented resources and data sources" list |
+| New `make` target in `GNUmakefile` | "Commands" section |
+| New Go package under `internal/` | "Architecture" section |
+| New provider-wide convention | "Provider coding conventions" section |
+
+For agent memories, check if the session revealed a pattern that agents got wrong or a non-obvious project idiom — record it in the relevant agent's memory directory.
+
+Skip anything already documented. Skip anything derivable by reading the code.
+
+### Step 3 — Update
+
+Edit only files where something is genuinely missing or stale. Prefer adding to existing sections.
+
+Do NOT:
+- Duplicate content already in CLAUDE.md or agent files
+- Make agent MD files longer
+- Record ephemeral session details
+
+### Step 4 — Report
+
+List each file updated and what was added (one line per change). If nothing needed updating, say so.

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -27,6 +28,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &EnvironmentResource{}
 var _ resource.ResourceWithImportState = &EnvironmentResource{}
+var _ resource.ResourceWithModifyPlan = &EnvironmentResource{}
 
 func NewEnvironmentResource() resource.Resource {
 	return &EnvironmentResource{}
@@ -119,12 +121,14 @@ func (r *EnvironmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Optional description of the environment.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"metadata": schema.MapAttribute{
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "User-provided metadata key-value pairs.",
+				PlanModifiers:       []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
 			},
 			"config": schema.SingleNestedAttribute{
 				Optional:            true,
@@ -262,6 +266,36 @@ func (r *EnvironmentResource) Configure(_ context.Context, req resource.Configur
 	}
 
 	r.client = pd.Client
+}
+
+// --- ModifyPlan ---
+
+// ModifyPlan keeps updated_at stable on no-op plans and marks it unknown when
+// mutable attributes are changing, to avoid inconsistent-result-after-apply errors.
+func (r *EnvironmentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Only relevant during updates (both state and plan are non-null).
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var state, plan EnvironmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Name.Equal(state.Name) ||
+		!plan.Description.Equal(state.Description) ||
+		!plan.Metadata.Equal(state.Metadata) ||
+		!plan.Config.Equal(state.Config) {
+		// Resource is being updated; updated_at will change.
+		plan.UpdatedAt = types.StringUnknown()
+	} else {
+		// No-op plan; keep updated_at stable to avoid a spurious diff.
+		plan.UpdatedAt = state.UpdatedAt
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 }
 
 // --- Create ---


### PR DESCRIPTION
## What changed

- **`description` and `metadata`** (Optional+Computed): added `UseStateForUnknown()` plan modifiers to prevent spurious `(known after apply)` diffs on no-op plans.
- **`updated_at`**: added `ModifyPlan` to keep the state value on no-op plans and mark it unknown when mutable attributes are changing. `UseStateForUnknown()` alone causes a "Provider produced inconsistent result after apply" error on updates because it commits the plan to the old timestamp while the API returns a new one.
- **`ship` skill**: new skill that creates a branch, commits, pushes, and opens or updates a PR in one flow. Iteratively hardened: sentinel file to suppress the stop hook, `gh api PATCH` instead of `gh pr edit` (avoids Projects classic deprecation error), and temp-file body to avoid shell backtick interpolation.
- **`update-pr-description` skill**: same `gh api PATCH` + temp-file fixes applied.
- **`update-project-knowledge` skill**: removed stale hook sentinel step; expanded scope to include subagent MD files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)