### PR TITLE
refactor(retry): extract multipart upload retry into internal/retry

### DIFF
--- a/.claude/agent-memory/terraform-provider-implementer/MEMORY.md
+++ b/.claude/agent-memory/terraform-provider-implementer/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [internal/errors providerrors pattern](project_errors_package.md) — Use providerrors.Require* helpers in Configure; never write inline nil checks on pd.Client/pd.AdminClient
 - [Two-key provider model](project_api_key_model.md) — Standard resources use pd.Client (ANTHROPIC_API_KEY); admin/org resources use pd.AdminClient (ANTHROPIC_ADMIN_API_KEY)
+- [Multipart upload retry](project_multipart_upload_retry.md) — File-uploading resources must use provretry.MultipartUpload; SDK cannot retry streaming multipart bodies

--- a/.claude/agent-memory/terraform-provider-implementer/project_multipart_upload_retry.md
+++ b/.claude/agent-memory/terraform-provider-implementer/project_multipart_upload_retry.md
@@ -1,0 +1,31 @@
+---
+name: Multipart file upload retry
+description: Resources that upload files must use provretry.MultipartUpload; the SDK cannot retry streaming multipart bodies on its own
+type: project
+---
+
+## Use provretry.MultipartUpload for any file-uploading resource
+
+The Anthropic Go SDK has built-in 5xx retry logic, but it skips retry when
+`req.GetBody == nil`. Streaming multipart uploads always have `GetBody == nil`
+(the body is a one-shot stream), so 5xx errors are silently not retried.
+
+Use `provretry.MultipartUpload` from `internal/retry/` instead of opening files
+manually:
+
+```go
+import provretry "github.com/ippontech/terraform-provider-anthropic/internal/retry"
+
+result, err := provretry.MultipartUpload(ctx, filePaths, dirName,
+    func(files []io.Reader) (*anthropic.BetaSkillNewResponse, error) {
+        return r.client.Beta.Skills.New(ctx, anthropic.BetaSkillNewParams{Files: files})
+    },
+)
+```
+
+The helper re-opens files from disk on each attempt (up to 3 tries, 5s/10s
+backoff) and returns immediately on non-5xx errors or file-open errors.
+
+**How to apply:** Any new resource whose `Create` method opens `os.File` handles
+and passes them to an API call must use `provretry.MultipartUpload`. Never
+replicate the retry loop inline.

--- a/.claude/agent-memory/terraform-provider-review/MEMORY.md
+++ b/.claude/agent-memory/terraform-provider-review/MEMORY.md
@@ -5,3 +5,4 @@
 - [Environment resources architecture](project_environment_resources.md) — Four branches added environment CRUD + archive + data sources; tracks patterns and issues fixed
 - [Configure method providerrors pattern](project_configure_pattern.md) — Flag inline nil checks on pd.Client/pd.AdminClient; must use providerrors.Require* helpers from internal/errors/
 - [Test file placement](project_test_placement.md) — Tests must live next to the code they test; admin package tests belong in admin_client_test.go, not workspace files
+- [Plan modifier patterns](project_plan_modifier_patterns.md) — UseStateForUnknown for stable Computed attrs; ModifyPlan for timestamps that change on updates

--- a/.claude/agent-memory/terraform-provider-review/project_plan_modifier_patterns.md
+++ b/.claude/agent-memory/terraform-provider-review/project_plan_modifier_patterns.md
@@ -1,0 +1,62 @@
+---
+name: Plan modifier patterns for Computed attributes
+description: UseStateForUnknown and ModifyPlan patterns to avoid non-empty plans and inconsistent-result errors on Computed/Optional+Computed attributes
+type: project
+---
+
+## Required plan modifiers on Computed and Optional+Computed attributes
+
+Without plan modifiers, `Computed` and `Optional+Computed` attributes are marked
+`(known after apply)` on every plan — even when nothing changed — causing the
+"non-empty plan after apply" test failure.
+
+### UseStateForUnknown — for attributes that don't change unless the resource is updated
+
+Add to **all** `Computed` and `Optional+Computed` attributes that hold a stable
+server-assigned value (IDs, creation timestamps, optional fields the API may
+populate but the user didn't configure):
+
+```go
+PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}
+// also: mapplanmodifier, objectplanmodifier, boolplanmodifier, etc.
+```
+
+**Why:** Without it, every `terraform plan` after apply shows these as
+`(known after apply)`, producing a non-empty plan and failing the idempotency
+check in acceptance tests.
+
+### ModifyPlan — for timestamps that change on every update
+
+`UseStateForUnknown()` alone is **wrong** for attributes like `updated_at` that
+the API silently mutates whenever the resource is updated. The plan would commit
+to the old value, but apply returns a new one → "Provider produced inconsistent
+result after apply" error.
+
+Implement `resource.ResourceWithModifyPlan` instead:
+
+```go
+var _ resource.ResourceWithModifyPlan = &MyResource{}
+
+func (r *MyResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+    if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+        return // create or destroy — nothing to do
+    }
+    var state, plan MyResourceModel
+    resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+    resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    if !plan.Name.Equal(state.Name) || /* other mutable attrs */ {
+        plan.UpdatedAt = types.StringUnknown() // will change — show as unknown
+    } else {
+        plan.UpdatedAt = state.UpdatedAt // no-op plan — keep stable
+    }
+    resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
+```
+
+**How to apply:** Flag any resource PR where a `Computed: true` timestamp
+attribute (e.g. `updated_at`, `last_modified_at`) lacks both `UseStateForUnknown`
+and a `ModifyPlan` implementation. Check that pure `UseStateForUnknown` on such
+attributes is never used alone without `ModifyPlan`.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -78,17 +78,17 @@ Then check whether an open PR already exists for this branch:
 gh pr view --json number,url --jq '"\(.number) \(.url)"' 2>/dev/null
 ```
 
-**If no open PR exists** — create one. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body:
+**If no open PR exists** — write the body to a temp file, then create the PR. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body:
 
 ```bash
-gh pr create \
-  --title "<commit title>" \
-  --body "$(cat <<'EOF'
+cat > /tmp/pr_body.txt << 'ENDBODY'
 <commit body>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+ENDBODY
+gh pr create \
+  --title "<commit title>" \
+  --body-file /tmp/pr_body.txt
 ```
 
 **If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR via the GitHub API (`gh pr edit` can fail with a Projects classic deprecation error):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,10 @@ r.client = pd.Client
 
 ### Shared helpers
 
-Helpers shared across resources/data sources go in `internal/errors/`, not `internal/provider/`.
+Helpers shared across resources/data sources live in `internal/`, not `internal/provider/`:
+
+- `internal/errors/` (import alias `providerrors`) — nil-client guards for `Configure` methods
+- `internal/retry/` (import alias `provretry`) — multipart file upload with automatic 5xx retry; use `provretry.MultipartUpload` for any resource that uploads files to the API (the Anthropic SDK cannot retry streaming multipart bodies on its own)
 
 ### Version constraints
 
@@ -133,3 +136,7 @@ Commits and MR titles must follow [conventional commits](https://www.conventiona
 - `chore:` maintenance
 
 PRs are squash-merged; the MR title becomes the commit message.
+
+### Go unit tests
+
+After any bug fix, refactoring, or new helper added under `internal/`, write or update Go unit tests in the same package before considering the task done. Unit tests live next to the code they test (e.g. `internal/retry/multipart_test.go` for `internal/retry/multipart.go`). Run `make test` to verify they pass.

--- a/internal/provider/skill_resource.go
+++ b/internal/provider/skill_resource.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -23,18 +22,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	providerrors "github.com/ippontech/terraform-provider-anthropic/internal/errors"
+	provretry "github.com/ippontech/terraform-provider-anthropic/internal/retry"
 )
-
-// namedReader wraps an io.Reader with an explicit multipart filename.
-// The Anthropic SDK encoder checks for Filename() before falling back to
-// path.Base(Name()), so this lets us send "dirname/file.md" instead of just "file.md".
-// The API requires every file to be inside a named top-level folder.
-type namedReader struct {
-	io.Reader
-	filename string
-}
-
-func (r namedReader) Filename() string { return r.filename }
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &SkillResource{}
@@ -151,45 +140,24 @@ func (r *SkillResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// Open each file.
 	var filePaths []string
 	resp.Diagnostics.Append(data.Files.ElementsAs(ctx, &filePaths, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	files := make([]io.Reader, 0, len(filePaths))
-	openedFiles := make([]*os.File, 0, len(filePaths))
-	defer func() {
-		for _, f := range openedFiles {
-			_ = f.Close()
-		}
-	}()
-
 	// The API requires every file to live inside a named top-level directory
 	// (e.g. "myskill/SKILL.md"). We derive that directory name from the common
 	// parent of the provided paths.
 	dirName := filepath.Base(filepath.Dir(filePaths[0]))
 
-	for _, p := range filePaths {
-		f, err := os.Open(p)
-		if err != nil {
-			resp.Diagnostics.AddError("File Open Error", fmt.Sprintf("Unable to open file %q: %s", p, err))
-			return
+	skill, err := provretry.MultipartUpload(ctx, filePaths, dirName, func(files []io.Reader) (*anthropic.BetaSkillNewResponse, error) {
+		params := anthropic.BetaSkillNewParams{Files: files}
+		if !data.DisplayTitle.IsNull() && !data.DisplayTitle.IsUnknown() {
+			params.DisplayTitle = anthropic.String(data.DisplayTitle.ValueString())
 		}
-		openedFiles = append(openedFiles, f)
-		files = append(files, namedReader{Reader: f, filename: dirName + "/" + filepath.Base(p)})
-	}
-
-	params := anthropic.BetaSkillNewParams{
-		Files: files,
-	}
-
-	if !data.DisplayTitle.IsNull() && !data.DisplayTitle.IsUnknown() {
-		params.DisplayTitle = anthropic.String(data.DisplayTitle.ValueString())
-	}
-
-	skill, err := r.client.Beta.Skills.New(ctx, params)
+		return r.client.Beta.Skills.New(ctx, params)
+	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create skill: %s", err))
 		return

--- a/internal/provider/skill_version_resource.go
+++ b/internal/provider/skill_version_resource.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	providerrors "github.com/ippontech/terraform-provider-anthropic/internal/errors"
+	provretry "github.com/ippontech/terraform-provider-anthropic/internal/retry"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -130,35 +130,18 @@ func (r *SkillVersionResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	// Open each file.
 	var filePaths []string
 	resp.Diagnostics.Append(data.Files.ElementsAs(ctx, &filePaths, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	files := make([]io.Reader, 0, len(filePaths))
-	openedFiles := make([]*os.File, 0, len(filePaths))
-	defer func() {
-		for _, f := range openedFiles {
-			_ = f.Close()
-		}
-	}()
-
 	dirName := filepath.Base(filepath.Dir(filePaths[0]))
 
-	for _, p := range filePaths {
-		f, err := os.Open(p)
-		if err != nil {
-			resp.Diagnostics.AddError("File Open Error", fmt.Sprintf("Unable to open file %q: %s", p, err))
-			return
-		}
-		openedFiles = append(openedFiles, f)
-		files = append(files, namedReader{Reader: f, filename: dirName + "/" + filepath.Base(p)})
-	}
-
-	skillVersion, err := r.client.Beta.Skills.Versions.New(ctx, data.SkillID.ValueString(), anthropic.BetaSkillVersionNewParams{
-		Files: files,
+	skillVersion, err := provretry.MultipartUpload(ctx, filePaths, dirName, func(files []io.Reader) (*anthropic.BetaSkillVersionNewResponse, error) {
+		return r.client.Beta.Skills.Versions.New(ctx, data.SkillID.ValueString(), anthropic.BetaSkillVersionNewParams{
+			Files: files,
+		})
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create skill version: %s", err))

--- a/internal/retry/multipart.go
+++ b/internal/retry/multipart.go
@@ -1,0 +1,106 @@
+// Copyright (c) Ippon
+// SPDX-License-Identifier: MPL-2.0
+
+// Package retry provides retry helpers for operations that the Anthropic SDK
+// cannot retry automatically.
+//
+// Multipart file uploads set req.Body without req.GetBody, so the SDK's
+// built-in retry logic (which requires a replayable body) is bypassed for
+// all 5xx responses. MultipartUpload works around this by re-opening files
+// from disk on each attempt.
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// NamedReader wraps an io.Reader with an explicit multipart filename.
+// The Anthropic SDK encoder checks for Filename() before falling back to
+// the struct field name, which is required for the API to accept the upload.
+type NamedReader struct {
+	io.Reader
+	name string
+}
+
+// NewNamedReader returns a NamedReader that reports filename as its multipart name.
+func NewNamedReader(r io.Reader, filename string) NamedReader {
+	return NamedReader{Reader: r, name: filename}
+}
+
+// Filename satisfies the SDK's optional naming interface.
+func (r NamedReader) Filename() string { return r.name }
+
+// backoff returns the delay before the given retry attempt.
+// Replaced by tests to avoid real sleeps.
+var backoff = func(attempt int) time.Duration {
+	return time.Duration(attempt) * 5 * time.Second
+}
+
+// MultipartUpload opens filePaths fresh on each attempt and calls fn with the
+// resulting readers, retrying up to 3 times on 5xx API errors with backoff.
+//
+// dirName is prepended to each file's base name in the multipart body (the
+// Anthropic API requires all files to live inside a named top-level directory,
+// and that name must match the `name` field in SKILL.md).
+//
+// File-open errors and non-5xx API errors are returned immediately without
+// retrying.
+func MultipartUpload[T any](ctx context.Context, filePaths []string, dirName string, fn func([]io.Reader) (T, error)) (T, error) {
+	const maxAttempts = 3
+	var zero T
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(backoff(attempt)):
+			}
+		}
+
+		files, openedFiles, err := openFiles(filePaths, dirName)
+		if err != nil {
+			return zero, err
+		}
+
+		result, err := fn(files)
+		closeAll(openedFiles)
+		if err == nil {
+			return result, nil
+		}
+
+		var apierr *anthropic.Error
+		if !errors.As(err, &apierr) || apierr.StatusCode < 500 || attempt == maxAttempts-1 {
+			return zero, err
+		}
+	}
+	return zero, nil // unreachable
+}
+
+func openFiles(filePaths []string, dirName string) ([]io.Reader, []*os.File, error) {
+	files := make([]io.Reader, 0, len(filePaths))
+	opened := make([]*os.File, 0, len(filePaths))
+	for _, p := range filePaths {
+		f, err := os.Open(p)
+		if err != nil {
+			closeAll(opened)
+			return nil, nil, fmt.Errorf("unable to open file %q: %w", p, err)
+		}
+		opened = append(opened, f)
+		files = append(files, NewNamedReader(f, dirName+"/"+filepath.Base(p)))
+	}
+	return files, opened, nil
+}
+
+func closeAll(files []*os.File) {
+	for _, f := range files {
+		_ = f.Close()
+	}
+}

--- a/internal/retry/multipart_test.go
+++ b/internal/retry/multipart_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) Ippon
+// SPDX-License-Identifier: MPL-2.0
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// noBackoff replaces the package-level backoff function with a no-op for the
+// duration of a test, so retry loops complete without real sleeps.
+func noBackoff(t *testing.T) {
+	t.Helper()
+	old := backoff
+	backoff = func(_ int) time.Duration { return 0 }
+	t.Cleanup(func() { backoff = old })
+}
+
+// apiErr builds a minimal *anthropic.Error with the given HTTP status code.
+func apiErr(statusCode int) *anthropic.Error {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/test", nil)
+	return &anthropic.Error{
+		StatusCode: statusCode,
+		Request:    req,
+		Response:   &http.Response{StatusCode: statusCode},
+	}
+}
+
+// writeFile creates a file with the given content inside dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+	return p
+}
+
+// ---- NamedReader ----
+
+func TestNamedReader_Filename(t *testing.T) {
+	r := NewNamedReader(strings.NewReader("data"), "mydir/SKILL.md")
+	if got := r.Filename(); got != "mydir/SKILL.md" {
+		t.Errorf("Filename() = %q, want %q", got, "mydir/SKILL.md")
+	}
+}
+
+func TestNamedReader_Read(t *testing.T) {
+	r := NewNamedReader(strings.NewReader("hello"), "dir/file.md")
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("Read content = %q, want %q", string(got), "hello")
+	}
+}
+
+// ---- MultipartUpload ----
+
+func TestMultipartUpload_SuccessOnFirstAttempt(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	calls := 0
+	result, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q, want %q", result, "ok")
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
+
+func TestMultipartUpload_RetriesOn5xx(t *testing.T) {
+	noBackoff(t)
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	calls := 0
+	result, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		if calls < 2 {
+			return "", apiErr(500)
+		}
+		return "ok", nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q, want %q", result, "ok")
+	}
+	if calls != 2 {
+		t.Errorf("fn called %d times, want 2", calls)
+	}
+}
+
+func TestMultipartUpload_ExhaustsMaxAttempts(t *testing.T) {
+	noBackoff(t)
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "", apiErr(503)
+	})
+
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+	var apierr *anthropic.Error
+	if !errors.As(err, &apierr) || apierr.StatusCode != 503 {
+		t.Errorf("expected 503 API error, got %v", err)
+	}
+}
+
+func TestMultipartUpload_NoRetryOn4xx(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "", apiErr(400)
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1 (no retry on 4xx)", calls)
+	}
+}
+
+func TestMultipartUpload_NoRetryOnNonAPIError(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "", errors.New("connection reset")
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1 (no retry on non-API error)", calls)
+	}
+}
+
+func TestMultipartUpload_FileOpenError(t *testing.T) {
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{"/nonexistent/path/SKILL.md"}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	if err == nil {
+		t.Fatal("expected file-open error")
+	}
+	if !strings.Contains(err.Error(), "unable to open file") {
+		t.Errorf("expected 'unable to open file' in error, got: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("fn called %d times, want 0 (file open failed)", calls)
+	}
+}
+
+func TestMultipartUpload_ContextCancelledDuringBackoff(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so the backoff select fires immediately on attempt 1
+
+	calls := 0
+	_, err := MultipartUpload(ctx, []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+		calls++
+		return "", apiErr(500) // triggers a retry attempt
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1 (cancelled before second attempt)", calls)
+	}
+}
+
+func TestMultipartUpload_FileNamingUseDirName(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "content")
+
+	var gotFilename string
+	_, _ = MultipartUpload(context.Background(), []string{p}, "myskill", func(files []io.Reader) (string, error) {
+		if named, ok := files[0].(interface{ Filename() string }); ok {
+			gotFilename = named.Filename()
+		}
+		return "ok", nil
+	})
+
+	want := "myskill/SKILL.md"
+	if gotFilename != want {
+		t.Errorf("multipart filename = %q, want %q", gotFilename, want)
+	}
+}
+
+func TestMultipartUpload_FileContentReadable(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "---\nname: test\n---\n")
+
+	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(files []io.Reader) (string, error) {
+		data, err := io.ReadAll(files[0])
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMultipartUpload_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeFile(t, dir, "SKILL.md", "skill content")
+	p2 := writeFile(t, dir, "extra.md", "extra content")
+
+	var gotCount int
+	_, _ = MultipartUpload(context.Background(), []string{p1, p2}, "mydir", func(files []io.Reader) (string, error) {
+		gotCount = len(files)
+		return "ok", nil
+	})
+
+	if gotCount != 2 {
+		t.Errorf("fn received %d files, want 2", gotCount)
+	}
+}
+
+func TestMultipartUpload_FilesReopenedOnRetry(t *testing.T) {
+	noBackoff(t)
+	dir := t.TempDir()
+	p := writeFile(t, dir, "SKILL.md", "data")
+
+	// Collect all file reads across attempts to confirm fresh opens on each retry.
+	var contents []string
+	MultipartUpload(context.Background(), []string{p}, "mydir", func(files []io.Reader) (string, error) { //nolint:errcheck
+		data, _ := io.ReadAll(files[0])
+		contents = append(contents, string(data))
+		if len(contents) < 2 {
+			return "", apiErr(500)
+		}
+		return "ok", nil
+	})
+
+	for i, c := range contents {
+		if c != "data" {
+			t.Errorf("attempt %d: file content = %q, want %q", i+1, c, "data")
+		}
+	}
+	if len(contents) != 2 {
+		t.Errorf("got %d attempts, want 2", len(contents))
+	}
+}


### PR DESCRIPTION
## Summary

- Extract a shared `internal/retry.MultipartUpload[T]` helper to fix silent 5xx retry failures on multipart uploads — the Anthropic SDK skips its built-in retry when `req.GetBody == nil` (streaming bodies), so transient server errors surfaced as permanent failures in `skill_resource` and `skill_version_resource`
- Simplify both resource `Create` methods by delegating to the shared helper, removing ~60 lines of duplicated open/close/retry logic
- Fix `/ship` skill to write the PR body to a temp file and use `--body-file` / `--raw-field`, preventing literal `\n` and null-coercion in PR descriptions

## What changed

- `internal/retry/multipart.go` — new package with `MultipartUpload[T any]` (up to 3 attempts, 5s/10s backoff, re-opens files from disk on each retry) and `NamedReader` (carries the `dirName/filename` path the API requires)
- `internal/retry/multipart_test.go` — 13 unit tests covering success, retry exhaustion, 4xx/non-API bail, file-open errors, context cancellation, filename format, content readability, multiple files, and fresh re-open on retry
- `internal/provider/skill_resource.go`, `skill_version_resource.go` — Create methods now use `provretry.MultipartUpload`
- `.claude/skills/ship/SKILL.md` — use `--body-file` for `gh pr create` and `--raw-field` for PATCH updates
- `CLAUDE.md` — document `internal/retry/` and add standing instruction to write unit tests after bug fixes and refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)