### PR TITLE
chore(skills): fix PR description formatting and gh pr view exit-code error

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -75,7 +75,8 @@ git push -u origin <branch-name>
 Then check whether an open PR already exists for this branch:
 
 ```bash
-gh pr view --json number,url --jq '"\(.number) \(.url)"' 2>/dev/null
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json number,url \
+  --jq 'if length > 0 then "\(.[0].number) \(.[0].url)" else "" end'
 ```
 
 **If no open PR exists** — write the body to a temp file, then create the PR. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body. **Write each bullet as a single unbroken line — do not hard-wrap at 80 chars, as continuation lines render as visible line breaks on GitHub.**

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -78,7 +78,7 @@ Then check whether an open PR already exists for this branch:
 gh pr view --json number,url --jq '"\(.number) \(.url)"' 2>/dev/null
 ```
 
-**If no open PR exists** — write the body to a temp file, then create the PR. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body:
+**If no open PR exists** — write the body to a temp file, then create the PR. The title must be the commit title (first line, without the `Co-Authored-By` trailer). The body must be the commit body. **Write each bullet as a single unbroken line — do not hard-wrap at 80 chars, as continuation lines render as visible line breaks on GitHub.**
 
 ```bash
 cat > /tmp/pr_body.txt << 'ENDBODY'
@@ -91,7 +91,7 @@ gh pr create \
   --body-file /tmp/pr_body.txt
 ```
 
-**If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR via the GitHub API (`gh pr edit` can fail with a Projects classic deprecation error):
+**If an open PR already exists** — synthesise an updated description from all commits on this branch since main, then update the PR via the GitHub API (`gh pr edit` can fail with a Projects classic deprecation error). **Write each bullet as a single unbroken line — do not hard-wrap at 80 chars.**
 
 ```bash
 git log main..HEAD --format="%s%n%n%b"   # all commit titles + bodies
@@ -103,8 +103,8 @@ cat > /tmp/pr_body.txt << 'ENDBODY'
 ENDBODY
 gh api repos/{owner}/{repo}/pulls/<number> \
   --method PATCH \
-  --field title="<title reflecting all commits>" \
-  --field body="$(cat /tmp/pr_body.txt)" \
+  --raw-field title="<title reflecting all commits>" \
+  --raw-field body="$(cat /tmp/pr_body.txt)" \
   --jq '.html_url'
 ```
 

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -33,8 +33,9 @@ git diff main...HEAD --stat          # files changed vs main
 
 ### Step 2 — Find the open PR
 
-Use `mcp__github__pull_request_read` (method: `get`) with the current branch
-name to retrieve the PR number and existing description.
+```bash
+gh pr view --json number,body --jq '{number: .number, body: .body}' 2>/dev/null
+```
 
 If no open PR exists for this branch, stop silently.
 
@@ -65,6 +66,7 @@ Guidelines:
 - One bullet per logical change — do not list individual files
 - Do not invent claims about behaviour you have not observed in this session
 - Keep it concise: a reviewer should understand the PR in under 30 seconds
+- **Write each bullet as a single unbroken line — do not hard-wrap at 80 chars**, as continuation lines render as visible line breaks on GitHub
 
 ### Step 4 — Update the PR
 
@@ -77,7 +79,7 @@ cat > /tmp/pr_body.txt << 'ENDBODY'
 ENDBODY
 gh api repos/{owner}/{repo}/pulls/<number> \
   --method PATCH \
-  --field body="$(cat /tmp/pr_body.txt)" \
+  --raw-field body="$(cat /tmp/pr_body.txt)" \
   --jq '.html_url'
 ```
 

--- a/.claude/skills/update-pr-description/SKILL.md
+++ b/.claude/skills/update-pr-description/SKILL.md
@@ -34,7 +34,8 @@ git diff main...HEAD --stat          # files changed vs main
 ### Step 2 — Find the open PR
 
 ```bash
-gh pr view --json number,body --jq '{number: .number, body: .body}' 2>/dev/null
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json number,url \
+  --jq 'if length > 0 then "number=\(.[0].number) url=\(.[0].url)" else "" end'
 ```
 
 If no open PR exists for this branch, stop silently.


### PR DESCRIPTION
Three bugs caused malformed PR descriptions when using `/ship` and `/update-pr-description`, now fixed:

- `gh api --field` infers JSON types and can coerce multi-line strings to `null`; switched to `--raw-field` which always passes the value as a plain string
- Hard-wrapped bullet continuation lines (2-space indent) render as visible line breaks on GitHub; added explicit instruction to write each bullet as a single unbroken line
- `update-pr-description` Step 2 referenced an unavailable MCP tool; replaced with `gh pr list`
- `gh pr view` exits 1 when no PR exists, which Claude Code reports as a tool error; replaced with `gh pr list` which always exits 0 and returns an empty array when no PR exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)