### PR TITLE
refactor(docs): rename subcategory "Agents" to "Managed Agents"

### DIFF
--- a/docs/data-sources/agent.md
+++ b/docs/data-sources/agent.md
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agent Data Source - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Retrieves a Managed Agent by ID.
 ---

--- a/docs/data-sources/agents.md
+++ b/docs/data-sources/agents.md
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agents Data Source - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Lists Managed Agents on the Anthropic platform (beta). Supports filtering by creation time, archive status, and a per-page limit; all pages are fetched automatically.
 ---

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agent Resource - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Creates and manages a Managed Agent on the Anthropic platform (beta). Agents are persistent configurations that can be used to run sessions with tools, MCP servers, and skills.
 ---

--- a/templates/data-sources/agent.md.tmpl
+++ b/templates/data-sources/agent.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agent Data Source - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Retrieves a Managed Agent by ID.
 ---

--- a/templates/data-sources/agents.md.tmpl
+++ b/templates/data-sources/agents.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agents Data Source - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Lists Managed Agents on the Anthropic platform (beta). Supports filtering by creation time, archive status, and a per-page limit; all pages are fetched automatically.
 ---

--- a/templates/resources/agent.md.tmpl
+++ b/templates/resources/agent.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "anthropic_agent Resource - anthropic"
-subcategory: "Agents"
+subcategory: "Managed Agents"
 description: |-
   Creates and manages a Managed Agent on the Anthropic platform (beta). Agents are persistent configurations that can be used to run sessions with tools, MCP servers, and skills.
 ---


### PR DESCRIPTION
Anthropic's documentation consistently uses "Claude Managed Agents" for this family. Aligning the Terraform Registry subcategory with that terminology makes it easier to find agent-related resources and prepares the ground for upcoming resources (environment, vault, vault_credential).

## Changes
- Updated `subcategory` frontmatter in `templates/resources/agent.md.tmpl`
- Updated `subcategory` frontmatter in `templates/data-sources/agent.md.tmpl`
- Updated `subcategory` frontmatter in `templates/data-sources/agents.md.tmpl`
- Regenerated `docs/` with `make generate`

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
