### PR TITLE
chore: improve skills and add ANTHROPIC_ADMIN_API_KEY to CI

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -2,9 +2,11 @@
 name: brainstorming
 description: >
   Plans and scaffolds Anthropic API endpoints as Terraform resources/data sources
-  without a task management tool. Use when starting work on a new API
-  (e.g. /v1/skills, /v1/environments) to discover endpoints, design the Terraform
-  schema, and generate GitHub issues and branches — one per resource/data source —
+  without a task management tool. TRIGGER when: user says "implement GitHub issues", references
+  a range of GitHub issues to implement (e.g. "issues 52 to 57"), asks to
+  parallelize implementation of multiple resources/data sources, or says
+  "implement all [API name] APIs" or "work on a new API" (e.g. /v1/skills, /v1/environments).
+  Generates GitHub issues and branches if they to not already exist — one per resource/data source —
   ready for sequential or parallel implementation.
 model: opus
 ---

--- a/.claude/skills/vibe-kanban-brainstorming/SKILL.md
+++ b/.claude/skills/vibe-kanban-brainstorming/SKILL.md
@@ -2,11 +2,11 @@
 name: vibe-kanban-brainstorming
 description: >
   Plans and scaffolds Anthropic API endpoints as Terraform resources/data sources
-  for Vibe Kanban — a multi-agent CLI tool that spawns one Claude Code agent per
-  issue, each isolated in its own git worktree, all running in parallel. Use when
-  starting work on a new API (e.g. /v1/skills, /v1/environments) to generate
-  cross-linked Vibe Kanban issues, GitHub issues, and branches — one per
-  resource/data source — ready for agents to implement in parallel.
+  for Vibe Kanban. TRIGGER when: user says "implement GitHub issues", references
+  a range of GitHub issues to implement (e.g. "issues 52 to 57"), asks to
+  parallelize implementation of multiple resources/data sources, or says
+  "implement all [API name] APIs". Creates Vibe Kanban issues, workspaces, and
+  fires parallel agents — one per resource/data source.
 model: opus
 ---
 
@@ -32,7 +32,9 @@ Endpoint → Terraform mapping:
 
 ### Step 2 — Create Vibe Kanban issues
 
-One `mcp__vibe_kanban__create_issue` per resource/data source **plus one orchestration issue**, all top-level (`no parent_issue_id`), in a **single parallel message**.
+One `mcp__vibe_kanban__create_issue` per resource/data source **plus one orchestration issue**, all in a **single parallel message**.
+
+**All issues must be top-level: never set `parent_issue_id`.**
 
 Priorities: orchestration `high`, resources `high`, data sources `medium`.
 
@@ -41,8 +43,8 @@ Priorities: orchestration `high`, resources `high`, data sources `medium`.
 Track parallel implementation of <API name> resources and data sources.
 
 ## Workspaces to monitor
-- [ ] <Issue title A> — branch: feat/<name-a>
-- [ ] <Issue title B> — branch: feat/<name-b>
+- [ ] <Issue title A>
+- [ ] <Issue title B>
 
 ## Agent instructions
 Do NOT write code. Your job:
@@ -60,36 +62,58 @@ Call `mcp__vibe_kanban__create_issue_relationship` for all pairs in a **single p
 - Resource ↔ its data source(s): `related`
 - Single data source ↔ list data source: `related`
 
-### Step 4 — Create GitHub issues and branches
+### Step 4 — Create GitHub issues
 
 First check for existing issues to avoid duplicates:
 ```bash
 gh issue list --search "<resource name>" --json number,title,url
 ```
 
-For each **implementation issue only** (orchestration has no GitHub issue or branch), create via `gh` CLI:
+For each **implementation issue only** (orchestration has no GitHub issue), create via `gh` CLI in a **single parallel message**:
 ```bash
 gh issue create --title "<title>" --body "<body>"
-gh api repos/{owner}/{repo}/git/refs -f ref="refs/heads/feat/<name>" -f sha="$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq .object.sha)"
 ```
 
-Branch naming: `feat/<resource-name>-resource` or `feat/<name>-data-source`.
+Do **not** create `feat/` branches here — the agent's `/ship` skill creates the branch automatically when it opens a PR.
 
 ### Step 5 — Cross-link
 
 Update all Vibe Kanban issues in a **single parallel message**:
-- Implementation issues: prepend `GitHub Issue: <url>\nBranch: feat/<name>`
+- Implementation issues: prepend `GitHub Issue: <url>`
 - Orchestration issue: prepend a list of all GitHub issue URLs it tracks.
 
-### Step 6 — Inform the user
+### Step 6 — Create implementation workspaces
 
-Report a summary table. Remind: "Open a draft PR on each branch once the first commit is pushed."
+Call `mcp__vibe_kanban__start_workspace` for every **implementation** issue in a **single parallel message**. Always pass `"branch": "main"` — vibe-kanban auto-generates a `vk/` branch internally.
+
+```
+mcp__vibe_kanban__start_workspace({
+  name: "<resource-or-datasource-name>",
+  executor: "CLAUDE_CODE",
+  issue_id: "<vk-issue-id>",
+  repositories: [{"repo_id": "<repo-id>", "branch": "main"}]
+})
+```
+
+After all calls return a `workspace_id`, call `mcp__vibe_kanban__list_sessions` for each workspace to retrieve the session ID.
+
+If any `start_workspace` call returns an error: do **not** call `run_session_prompt` for that workspace — delete it and recreate it before proceeding.
+
+### Step 7 — Fire implementation prompts
+
+Call `mcp__vibe_kanban__run_session_prompt` for all sessions in a **single parallel message**. Each prompt must include the `/terraform-provider` skill invocation followed by the full spec (API endpoints, SDK methods, Terraform schema, files to create).
+
+### Step 8 — Inform the user
+
+Report a summary table of issues, GitHub issue URLs, and workspace IDs. Remind: "Each agent will open a draft PR via `/ship` when it's ready."
 
 ## Invariants
 
+- **All issues are top-level.** Never set `parent_issue_id` on any issue.
 - **One orchestration issue per batch.** No branch, no PR, no commits. Never skip it.
+- **`start_workspace` always uses `branch: "main"`.** Never pass a `feat/` or custom branch name — vibe-kanban generates its own `vk/` branch. Passing a non-existent branch causes a 400 error and leaves the worktree uninitialised, making subsequent `run_session_prompt` calls fail.
 - **One GitHub issue per implementation ticket.** URL written back into the Vibe Kanban description.
-- **One PR per ticket.** Never bundle multiple tickets.
+- **One PR per ticket.** Never bundle multiple tickets. The agent's `/ship` skill creates the branch and PR.
 - **No Vibe Kanban IDs outside Vibe Kanban** (not in commits, PR titles, or PR bodies — use `#N`).
 - **Branch isolation.** Each agent commits only to its own worktree branch.
 
@@ -99,9 +123,6 @@ Report a summary table. Remind: "Open a draft PR on each branch once the first c
 GitHub Issue: <url>
 
 <One-line summary.>
-
-## Branch
-`feat/<name>` (open draft PR after first commit)
 
 ## API
 - `METHOD /v1/<path>` — description
@@ -125,6 +146,8 @@ User: "I'd like to implement /v1/environments APIs"
 1. Fetch API docs in parallel → identify: `anthropic_environment` resource, `anthropic_environment` data source, `anthropic_environments` data source.
 2. Create **4** Kanban issues in parallel: 1 orchestration + 3 implementation.
 3. Create **5** relationships in parallel: 3× impl `blocking` orch, resource `related` single DS, single DS `related` list DS.
-4. Create **3** GitHub issues + **3** branches in parallel (implementation only).
-5. Update **4** Kanban issues with links in parallel.
-6. Report summary; remind user to open draft PRs.
+4. Create **3** GitHub issues in parallel (implementation only; no branches).
+5. Update **4** Kanban issues with GitHub links in parallel.
+6. Start **3** workspaces in parallel; retrieve session IDs.
+7. Fire **3** implementation prompts in parallel.
+8. Report summary.

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -46,6 +46,7 @@ jobs:
         run: make testacc
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_ADMIN_API_KEY: ${{ secrets.ANTHROPIC_ADMIN_API_KEY }}
 
   terraform-test:
     runs-on: ubuntu-latest
@@ -85,3 +86,4 @@ jobs:
         run: make terraform-test
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_ADMIN_API_KEY: ${{ secrets.ANTHROPIC_ADMIN_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ internal/
 **Go acceptance tests** (`internal/services/<service>/`):
 - Test files use `package <service>_test` (external test package), except tests that access unexported symbols which use `package <service>`
 - `internal/acctest/acctest.go` exports `ProtoV6ProviderFactories` and `PreCheck` used by all acceptance tests
+- Admin API acceptance tests: only read-only data source tests are possible today; resource tests (create/update/delete) are blocked by [#58](https://github.com/ippontech/terraform-provider-anthropic/issues/58). Add a `PreCheckAdmin` helper when that is resolved.
 - Unit tests: no special env vars needed
 - Acceptance tests: use `resource.Test(t, resource.TestCase{...})` with `TF_ACC=1`
 


### PR DESCRIPTION
## Summary

- **vibe-kanban-brainstorming skill**: add the missing workspace creation and prompt-firing steps (`start_workspace` + `run_session_prompt`), enforce top-level-only issues, drop pre-created `feat/` branches (agents use `/ship` instead), add `branch: "main"` invariant for `start_workspace`, update frontmatter triggers
- **brainstorming skill**: update frontmatter with an explicit TRIGGER clause to distinguish it from the vibe-kanban variant
- **testacc.yml**: pass `ANTHROPIC_ADMIN_API_KEY` secret to both `testacc` and `terraform-test` jobs so Admin API data source tests can run in CI
- **CLAUDE.md**: document the Admin API acceptance test limitation (blocked by #58) and the `PreCheck` vs future `PreCheckAdmin` split

## Test plan

- [x] Pre-commit hooks pass (yaml lint, GitHub Actions lint, semgrep, checkov, poutine)
- [x] Add `ANTHROPIC_ADMIN_API_KEY` secret to the `acctest` GitHub environment in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
