### PR TITLE
feat(environments): add archive_on_destroy to anthropic_environment resource

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,11 @@
             "type": "command",
             "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-pr-desc-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if gh pr view \"$branch\" --json state -q '.state' 2>/dev/null | grep -q \"OPEN\"; then jq -n --arg b \"$branch\" '{\"decision\":\"block\",\"reason\":(\"Open PR on branch \" + $b + \" — please invoke /update-pr-description to update the PR description.\")}'; fi",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ -z \"$branch\" ] || [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"HEAD\" ]; then exit 0; fi; sentinel=\"/tmp/claude-knowledge-done-$(echo \"$branch\" | tr '/' '-')\"; if [ -f \"$sentinel\" ] && [ $(( $(date +%s) - $(stat -c %Y \"$sentinel\") )) -lt 300 ]; then exit 0; fi; if git diff --name-only origin/main..HEAD 2>/dev/null | grep -qE \"\\.(go|tf)$\"; then jq -n '{\"decision\":\"block\",\"reason\":\"Code changes on this branch — invoke /update-project-knowledge to sync CLAUDE.md and memories.\"}'; fi",
+            "timeout": 15
           }
         ]
       }
@@ -27,7 +32,8 @@
   },
   "permissions": {
     "allow": [
-      "Bash(touch /tmp/claude-pr-desc-done-*)"
+      "Bash(touch /tmp/claude-pr-desc-done-*)",
+      "Bash(touch /tmp/claude-knowledge-done-*)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/update-project-knowledge/SKILL.md
+++ b/.claude/skills/update-project-knowledge/SKILL.md
@@ -55,3 +55,10 @@ Do NOT:
 ### Step 4 — Report
 
 List each file updated and what was added (one line per change). If nothing needed updating, say so.
+
+Then suppress the Stop hook reminder for this branch:
+
+```bash
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+touch "/tmp/claude-knowledge-done-$(echo "$branch" | tr '/' '-')"
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ internal/
 **Resources:**
 - `anthropic_message` (`internal/services/messages/message_resource.go`) — calls the Messages API; write-only, immutable (no read/update/delete)
 - `anthropic_agent` (`internal/services/agents/agent_resource.go`) — manages Managed Agents (create/read/update/delete)
-- `anthropic_environment` (`internal/services/environments/environment_resource.go`) — manages environments
+- `anthropic_environment` (`internal/services/environments/environment_resource.go`) — manages environments; supports `archive_on_destroy` (archives instead of deleting on destroy when true)
 - `anthropic_skill` (`internal/services/skills/skill_resource.go`) — manages skills
 - `anthropic_skill_version` (`internal/services/skills/skill_version_resource.go`) — manages skill versions
 - `anthropic_workspace` (`internal/services/workspaces/workspace_resource.go`) — manages workspaces (admin API)
@@ -98,6 +98,8 @@ A `.env` file at the project root sets machine-specific variables (e.g., `OTEL_T
 ```bash
 set -a && source .env && set +a
 ```
+
+After upgrading Go via mise, run `go clean -cache` before `make` to clear stale build artifacts. Without this, golangci-lint's typecheck step fails with a "version does not match go tool version" error because cached objects carry the old Go version tag.
 
 ## Commands
 
@@ -169,6 +171,43 @@ r.client = pd.Client
 - `internal/errors/` (import alias `providerrors`) — nil-client guards for `Configure` methods
 - `internal/providerdata/` (import alias `providerdata`) — `ProviderData` struct
 - `internal/retry/` (import alias `provretry`) — multipart file upload with automatic 5xx retry; use `provretry.MultipartUpload` for any resource that uploads files to the API (the Anthropic SDK cannot retry streaming multipart bodies on its own)
+
+### archive_on_destroy pattern
+
+Resources where the API supports archiving (non-destructive) as an alternative to hard-delete should expose an `archive_on_destroy` bool rather than a separate archive resource. Follow this shape exactly:
+
+```go
+// Schema attribute
+"archive_on_destroy": schema.BoolAttribute{
+    Optional:            true,
+    Computed:            true,
+    Default:             booldefault.StaticBool(false),
+    MarkdownDescription: "If `true`, destroying this resource archives it instead of permanently deleting it. Default: `false`.",
+    PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+},
+
+// Delete method
+if data.ArchiveOnDestroy.ValueBool() {
+    _, err := r.client.Beta.<Resource>.Archive(ctx, data.ID.ValueString(), ...)
+    // handle err
+    return
+}
+_, err := r.client.Beta.<Resource>.Delete(ctx, data.ID.ValueString(), ...)
+
+// Read method — default to false on import (field is not in API response)
+if data.ArchiveOnDestroy.IsNull() || data.ArchiveOnDestroy.IsUnknown() {
+    data.ArchiveOnDestroy = types.BoolValue(false)
+}
+```
+
+Acceptance tests whose `CheckDestroy` verifies archive behaviour must also hard-delete the environment afterwards to avoid dangling archived resources in the test org:
+
+```go
+func testAccCheck<Resource>ArchivedAndCleanup(s *terraform.State) error {
+    // 1. Get — assert ArchivedAt != ""
+    // 2. Delete — permanently remove to avoid accumulation
+}
+```
 
 ### Version constraints
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -27,6 +27,12 @@ resource "anthropic_environment" "minimal" {
   name = "minimal-environment"
 }
 
+# Environment archived instead of deleted on terraform destroy
+resource "anthropic_environment" "preserved" {
+  name               = "preserved-environment"
+  archive_on_destroy = true
+}
+
 # Environment with limited network and pip packages
 resource "anthropic_environment" "python_data" {
   name        = "python-data-analysis"
@@ -82,6 +88,7 @@ output "environment_networking_type" {
 
 ### Optional
 
+- `archive_on_destroy` (Boolean) If `true`, destroying this resource archives the environment instead of permanently deleting it. Default: `false`.
 - `config` (Attributes) Cloud environment configuration including networking and packages. (see [below for nested schema](#nestedatt--config))
 - `description` (String) Optional description of the environment.
 - `metadata` (Map of String) User-provided metadata key-value pairs.

--- a/examples/resources/environment/resource.tf
+++ b/examples/resources/environment/resource.tf
@@ -13,6 +13,12 @@ resource "anthropic_environment" "minimal" {
   name = "minimal-environment"
 }
 
+# Environment archived instead of deleted on terraform destroy
+resource "anthropic_environment" "preserved" {
+  name               = "preserved-environment"
+  archive_on_destroy = true
+}
+
 # Environment with limited network and pip packages
 resource "anthropic_environment" "python_data" {
   name        = "python-data-analysis"

--- a/internal/services/environments/environment_resource.go
+++ b/internal/services/environments/environment_resource.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -43,15 +45,16 @@ type EnvironmentResource struct {
 // --- Terraform data models ---
 
 type EnvironmentResourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Metadata    types.Map    `tfsdk:"metadata"`
-	Config      types.Object `tfsdk:"config"`
-	ArchivedAt  types.String `tfsdk:"archived_at"`
-	CreatedAt   types.String `tfsdk:"created_at"`
-	UpdatedAt   types.String `tfsdk:"updated_at"`
-	Type        types.String `tfsdk:"type"`
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Description      types.String `tfsdk:"description"`
+	Metadata         types.Map    `tfsdk:"metadata"`
+	Config           types.Object `tfsdk:"config"`
+	ArchivedAt       types.String `tfsdk:"archived_at"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	UpdatedAt        types.String `tfsdk:"updated_at"`
+	Type             types.String `tfsdk:"type"`
+	ArchiveOnDestroy types.Bool   `tfsdk:"archive_on_destroy"`
 }
 
 type environmentConfigModel struct {
@@ -242,6 +245,13 @@ func (r *EnvironmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Archive timestamp (RFC 3339). Null if the environment has not been archived.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"archive_on_destroy": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "If `true`, destroying this resource archives the environment instead of permanently deleting it. Default: `false`.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -368,6 +378,11 @@ func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// archive_on_destroy is local-only (not in the API); default to false when not already set (e.g. on import).
+	if data.ArchiveOnDestroy.IsNull() || data.ArchiveOnDestroy.IsUnknown() {
+		data.ArchiveOnDestroy = types.BoolValue(false)
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -435,10 +450,17 @@ func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	if data.ArchiveOnDestroy.ValueBool() {
+		_, err := r.client.Beta.Environments.Archive(ctx, data.ID.ValueString(), anthropic.BetaEnvironmentArchiveParams{})
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to archive environment: %s", err))
+		}
+		return
+	}
+
 	_, err := r.client.Beta.Environments.Delete(ctx, data.ID.ValueString(), anthropic.BetaEnvironmentDeleteParams{})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete environment: %s", err))
-		return
 	}
 }
 

--- a/internal/services/environments/environment_resource_test.go
+++ b/internal/services/environments/environment_resource_test.go
@@ -33,6 +33,29 @@ func testAccCheckEnvironmentDestroyed(s *terraform.State) error {
 	return nil
 }
 
+// testAccCheckEnvironmentArchivedAndCleanup verifies the environment was archived
+// (not hard-deleted) and then permanently deletes it to avoid dangling resources.
+func testAccCheckEnvironmentArchivedAndCleanup(s *terraform.State) error {
+	client := anthropic.NewClient(option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")))
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "anthropic_environment" {
+			continue
+		}
+		env, err := client.Beta.Environments.Get(context.Background(), rs.Primary.ID, anthropic.BetaEnvironmentGetParams{})
+		if err != nil {
+			return fmt.Errorf("environment %s not found after archive destroy: %w", rs.Primary.ID, err)
+		}
+		if env.ArchivedAt == "" {
+			return fmt.Errorf("environment %s was not archived on destroy", rs.Primary.ID)
+		}
+		// Hard-delete the archived environment so it doesn't accumulate in the org.
+		if _, err := client.Beta.Environments.Delete(context.Background(), rs.Primary.ID, anthropic.BetaEnvironmentDeleteParams{}); err != nil {
+			return fmt.Errorf("cleanup: unable to delete archived environment %s: %w", rs.Primary.ID, err)
+		}
+	}
+	return nil
+}
+
 const testAccEnvironmentResourceBasicConfig = `
 resource "anthropic_environment" "test" {
   name = "tf-acc-test-env-basic"
@@ -182,6 +205,38 @@ func TestAccEnvironmentResource_update(t *testing.T) {
 					resource.TestCheckResourceAttr("anthropic_environment.test", "name", "tf-acc-test-env-update-v2"),
 					resource.TestCheckResourceAttr("anthropic_environment.test", "description", "Updated description"),
 				),
+			},
+		},
+	})
+}
+
+const testAccEnvironmentResourceArchiveOnDestroyConfig = `
+resource "anthropic_environment" "test" {
+  name               = "tf-acc-test-env-archive-on-destroy"
+  archive_on_destroy = true
+}
+`
+
+func TestAccEnvironmentResource_archiveOnDestroy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentArchivedAndCleanup,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceArchiveOnDestroyConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("anthropic_environment.test", "id"),
+					resource.TestCheckResourceAttr("anthropic_environment.test", "name", "tf-acc-test-env-archive-on-destroy"),
+					resource.TestCheckResourceAttr("anthropic_environment.test", "archive_on_destroy", "true"),
+				),
+			},
+			// ImportState — archive_on_destroy is local-only; provider defaults it to false on import.
+			{
+				ResourceName:            "anthropic_environment.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"archive_on_destroy"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Add `archive_on_destroy` boolean field to `anthropic_environment` resource (replaces the dedicated `anthropic_environment_archive` resource from PR #73), following the same pattern as the GitLab provider
- Delete method branches: `archive_on_destroy = true` calls `Beta.Environments.Archive`; `false` (default) calls `Beta.Environments.Delete`
- Read method defaults `archive_on_destroy` to `false` on import so `terraform import` works without extra config
- New `TestAccEnvironmentResource_archiveOnDestroy` acceptance test with a `CheckDestroy` that verifies the environment was archived then hard-deletes it to avoid dangling resources in the test org
- Add Stop hook to `.claude/settings.json` that prompts `/update-project-knowledge` when `.go`/`.tf` changes exist on a non-main branch (same sentinel pattern as the existing `update-pr-description` hook)
- Document `archive_on_destroy` pattern and `go clean -cache` fix for mise Go upgrade in `CLAUDE.md`

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)