### PR TITLE
docs: standardize API/Auth/Beta header/Cost block across all resource and data source docs

### DIFF
--- a/docs/data-sources/agent.md
+++ b/docs/data-sources/agent.md
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a Managed Agent by ID.
 
+> **API**: `GET /v1/agents/{id}` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/agents.md
+++ b/docs/data-sources/agents.md
@@ -9,6 +9,11 @@ description: |-
 
 Lists Managed Agents on the Anthropic platform (beta). Supports filtering by creation time, archive status, and a per-page limit; all pages are fetched automatically.
 
+> **API**: `GET /v1/agents` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/count_tokens.md
+++ b/docs/data-sources/count_tokens.md
@@ -9,6 +9,11 @@ description: |-
 
 The `anthropic_count_tokens` data source counts the number of tokens that would be consumed by a message request without actually creating the message. This is useful for estimating API costs and validating that requests fit within model context windows before sending them.
 
+> **API**: `POST /v1/messages/count_tokens` (Messages API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free (rate-limited).
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic cloud environment by ID (beta).
 
+> **API**: `GET /v1/environments/{id}` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Anthropic cloud environments (beta). All pages are fetched automatically.
 
+> **API**: `GET /v1/environments` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/model.md
+++ b/docs/data-sources/model.md
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a specific Anthropic model by ID or alias.
 
+> **API**: `GET /v1/models/{id}` (Models API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/models.md
+++ b/docs/data-sources/models.md
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves the list of available Anthropic models.
 
+> **API**: `GET /v1/models` (Models API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/skill.md
+++ b/docs/data-sources/skill.md
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a Skill by ID.
 
+> **API**: `GET /v1/skills/{id}` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/skill_version.md
+++ b/docs/data-sources/skill_version.md
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a specific Skill Version by skill ID and version.
 
+> **API**: `GET /v1/skills/{skill_id}/versions/{version}` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/skill_versions.md
+++ b/docs/data-sources/skill_versions.md
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Skill Versions for a given Skill on the Anthropic platform (beta). All pages are fetched automatically.
 
+> **API**: `GET /v1/skills/{skill_id}/versions` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/skills.md
+++ b/docs/data-sources/skills.md
@@ -9,6 +9,11 @@ description: |-
 
 Lists available Skills on the Anthropic platform (beta). Supports optional filtering by source (`"custom"` or `"anthropic"`); all pages are fetched automatically.
 
+> **API**: `GET /v1/skills` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic Workspace by ID via the Admin API.
 
+> **API**: `GET /v1/organizations/workspaces/{id}` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/workspace_member.md
+++ b/docs/data-sources/workspace_member.md
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic workspace member by workspace ID and user ID.
 
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/members/{user_id}` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/data-sources/workspace_members.md
+++ b/docs/data-sources/workspace_members.md
@@ -9,7 +9,10 @@ description: |-
 
 Lists all members of an Anthropic Workspace via the Admin API. All pages are fetched automatically.
 
-Requires `admin_api_key` (or `ANTHROPIC_ADMIN_API_KEY`) to be configured on the provider.
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/members` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 ## Example Usage
 

--- a/docs/data-sources/workspace_rate_limits.md
+++ b/docs/data-sources/workspace_rate_limits.md
@@ -9,7 +9,10 @@ description: |-
 
 Lists workspace-level rate-limit overrides for a given workspace. Only entries that have at least one override are returned; groups inheriting organization-level limits are **not** listed.
 
-Requires `admin_api_key` (or `ANTHROPIC_ADMIN_API_KEY`) on the provider.
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/rate_limits` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 ## Example Usage
 

--- a/docs/data-sources/workspaces.md
+++ b/docs/data-sources/workspaces.md
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Anthropic Workspaces via the Admin API. All pages are fetched automatically.
 
+> **API**: `GET /v1/organizations/workspaces` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,12 @@ The `admin_api_key` is optional — you only need it when using workspace-relate
 ~> **Warning**: Never hardcode API keys in your Terraform configuration files.
 Use environment variables or a secrets manager instead.
 
+## Cost considerations
+
+~> **Warning**: Some resources call billable Anthropic APIs at `terraform apply` time and can generate unbounded variable cost. `anthropic_message` consumes tokens on every apply, and Managed Agents / Skills (created via `anthropic_agent`, `anthropic_environment`, `anthropic_skill`, `anthropic_skill_version`) are free to manage but billable when invoked at runtime. Combining these with `count`/`for_each` over a large input set, or omitting `max_tokens`, can produce a single apply that costs significantly more than expected.
+
+Each per-resource doc page lists its cost profile in an **API / Auth / Beta header / Cost** header block. Review it before scaling apply-time inference across many instances, and prefer setting an explicit `max_tokens` on every `anthropic_message`.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a Managed Agent on the Anthropic platform (beta). Agents are persistent configurations that can be used to run sessions with tools, MCP servers, and skills.
 
+> **API**: `POST/GET/PATCH/POST /v1/agents[/{id}][/archive]` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free for management, billable at runtime.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a cloud environment (container template) for Anthropic Managed Agent sessions (beta). Environments define the networking policy and pre-installed packages available to agent sessions.
 
+> **API**: `POST/GET/PATCH/DELETE /v1/environments[/{id}]` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free for management, billable at runtime.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/message.md
+++ b/docs/resources/message.md
@@ -9,6 +9,11 @@ description: |-
 
 Sends a message to an Anthropic model via the Messages API and stores the response. All input attributes trigger resource replacement on change.
 
+> **API**: `POST /v1/messages` (Messages API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Billable per apply (consumes tokens).
+
 ~> **Note:** This resource implements an immutable, write-only pattern. There is no persistent storage of messages beyond Terraform state; the resource calls the Anthropic Messages API during `terraform apply` and stores the response. Modifying any input attribute causes the resource to be replaced (a new API call is made). There is no `terraform refresh` from a remote API state.
 
 ## Example Usage

--- a/docs/resources/skill.md
+++ b/docs/resources/skill.md
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a custom Skill on the Anthropic platform (beta). Skills are uploaded from local files and can be attached to Managed Agents.
 
+> **API**: `POST/GET/DELETE /v1/skills[/{id}]` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free for management, billable when used.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/skill_version.md
+++ b/docs/resources/skill_version.md
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a Skill Version on the Anthropic platform (beta). A Skill Version is created by uploading local files to an existing Skill.
 
+> **API**: `POST/GET/DELETE /v1/skills/{skill_id}/versions[/{version}]` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free for management, billable when used.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -9,7 +9,10 @@ description: |-
 
 Creates and manages an Anthropic Workspace via the Admin API.
 
-Requires `admin_api_key` (or the `ANTHROPIC_ADMIN_API_KEY` environment variable) to be configured on the provider.
+> **API**: `POST/GET/POST/POST /v1/organizations/workspaces[/{id}][/archive]` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 > **Note on deletion:** Deleting this resource **archives** the workspace rather than permanently deleting it, because the Anthropic API does not expose a delete operation for workspaces. An archived workspace is removed from state and Terraform will recreate it on the next apply.
 

--- a/docs/resources/workspace_member.md
+++ b/docs/resources/workspace_member.md
@@ -9,7 +9,10 @@ description: |-
 
 Assigns a user to an Anthropic Workspace with a given role via the Admin API.
 
-Requires `admin_api_key` (or the `ANTHROPIC_ADMIN_API_KEY` environment variable) to be configured on the provider.
+> **API**: `POST/GET/POST/DELETE /v1/organizations/workspaces/{workspace_id}/members[/{user_id}]` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 > **Note:** The `workspace_billing` role cannot be assigned via this resource.
 

--- a/templates/data-sources/agent.md.tmpl
+++ b/templates/data-sources/agent.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a Managed Agent by ID.
 
+> **API**: `GET /v1/agents/{id}` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/agent/data_source.tf" }}

--- a/templates/data-sources/agents.md.tmpl
+++ b/templates/data-sources/agents.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Lists Managed Agents on the Anthropic platform (beta). Supports filtering by creation time, archive status, and a per-page limit; all pages are fetched automatically.
 
+> **API**: `GET /v1/agents` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/agents/data_source.tf" }}

--- a/templates/data-sources/count_tokens.md.tmpl
+++ b/templates/data-sources/count_tokens.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 The `anthropic_count_tokens` data source counts the number of tokens that would be consumed by a message request without actually creating the message. This is useful for estimating API costs and validating that requests fit within model context windows before sending them.
 
+> **API**: `POST /v1/messages/count_tokens` (Messages API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free (rate-limited).
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/count_tokens/data_source.tf" }}

--- a/templates/data-sources/environment.md.tmpl
+++ b/templates/data-sources/environment.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic cloud environment by ID (beta).
 
+> **API**: `GET /v1/environments/{id}` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/environment/data_source.tf" }}

--- a/templates/data-sources/environments.md.tmpl
+++ b/templates/data-sources/environments.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Anthropic cloud environments (beta). All pages are fetched automatically.
 
+> **API**: `GET /v1/environments` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/environments/data_source.tf" }}

--- a/templates/data-sources/model.md.tmpl
+++ b/templates/data-sources/model.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a specific Anthropic model by ID or alias.
 
+> **API**: `GET /v1/models/{id}` (Models API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/model/data_source.tf" }}

--- a/templates/data-sources/models.md.tmpl
+++ b/templates/data-sources/models.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves the list of available Anthropic models.
 
+> **API**: `GET /v1/models` (Models API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/models/data-source.tf" }}

--- a/templates/data-sources/skill.md.tmpl
+++ b/templates/data-sources/skill.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a Skill by ID.
 
+> **API**: `GET /v1/skills/{id}` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/skill/data_source.tf" }}

--- a/templates/data-sources/skill_version.md.tmpl
+++ b/templates/data-sources/skill_version.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Retrieves a specific Skill Version by skill ID and version.
 
+> **API**: `GET /v1/skills/{skill_id}/versions/{version}` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/skill_version/data_source.tf" }}

--- a/templates/data-sources/skill_versions.md.tmpl
+++ b/templates/data-sources/skill_versions.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Skill Versions for a given Skill on the Anthropic platform (beta). All pages are fetched automatically.
 
+> **API**: `GET /v1/skills/{skill_id}/versions` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/skill_versions/data_source.tf" }}

--- a/templates/data-sources/skills.md.tmpl
+++ b/templates/data-sources/skills.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Lists available Skills on the Anthropic platform (beta). Supports optional filtering by source (`"custom"` or `"anthropic"`); all pages are fetched automatically.
 
+> **API**: `GET /v1/skills` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/skills/data_source.tf" }}

--- a/templates/data-sources/workspace.md.tmpl
+++ b/templates/data-sources/workspace.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic Workspace by ID via the Admin API.
 
+> **API**: `GET /v1/organizations/workspaces/{id}` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/workspace/data_source.tf" }}

--- a/templates/data-sources/workspace_member.md.tmpl
+++ b/templates/data-sources/workspace_member.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Fetches a single Anthropic workspace member by workspace ID and user ID.
 
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/members/{user_id}` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/workspace_member/data-source.tf" }}

--- a/templates/data-sources/workspace_members.md.tmpl
+++ b/templates/data-sources/workspace_members.md.tmpl
@@ -9,7 +9,10 @@ description: |-
 
 Lists all members of an Anthropic Workspace via the Admin API. All pages are fetched automatically.
 
-Requires `admin_api_key` (or `ANTHROPIC_ADMIN_API_KEY`) to be configured on the provider.
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/members` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 ## Example Usage
 

--- a/templates/data-sources/workspace_rate_limits.md.tmpl
+++ b/templates/data-sources/workspace_rate_limits.md.tmpl
@@ -9,7 +9,10 @@ description: |-
 
 Lists workspace-level rate-limit overrides for a given workspace. Only entries that have at least one override are returned; groups inheriting organization-level limits are **not** listed.
 
-Requires `admin_api_key` (or `ANTHROPIC_ADMIN_API_KEY`) on the provider.
+> **API**: `GET /v1/organizations/workspaces/{workspace_id}/rate_limits` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 ## Example Usage
 

--- a/templates/data-sources/workspaces.md.tmpl
+++ b/templates/data-sources/workspaces.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Lists all Anthropic Workspaces via the Admin API. All pages are fetched automatically.
 
+> **API**: `GET /v1/organizations/workspaces` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/data-sources/workspaces/data_source.tf" }}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -58,6 +58,12 @@ The `admin_api_key` is optional — you only need it when using workspace-relate
 ~> **Warning**: Never hardcode API keys in your Terraform configuration files.
 Use environment variables or a secrets manager instead.
 
+## Cost considerations
+
+~> **Warning**: Some resources call billable Anthropic APIs at `terraform apply` time and can generate unbounded variable cost. `anthropic_message` consumes tokens on every apply, and Managed Agents / Skills (created via `anthropic_agent`, `anthropic_environment`, `anthropic_skill`, `anthropic_skill_version`) are free to manage but billable when invoked at runtime. Combining these with `count`/`for_each` over a large input set, or omitting `max_tokens`, can produce a single apply that costs significantly more than expected.
+
+Each per-resource doc page lists its cost profile in an **API / Auth / Beta header / Cost** header block. Review it before scaling apply-time inference across many instances, and prefer setting an explicit `max_tokens` on every `anthropic_message`.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/provider/provider.tf" }}

--- a/templates/resources/agent.md.tmpl
+++ b/templates/resources/agent.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a Managed Agent on the Anthropic platform (beta). Agents are persistent configurations that can be used to run sessions with tools, MCP servers, and skills.
 
+> **API**: `POST/GET/PATCH/POST /v1/agents[/{id}][/archive]` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free for management, billable at runtime.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/resources/agent/resource.tf" }}

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a cloud environment (container template) for Anthropic Managed Agent sessions (beta). Environments define the networking policy and pre-installed packages available to agent sessions.
 
+> **API**: `POST/GET/PATCH/DELETE /v1/environments[/{id}]` (Managed Agents API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: managed-agents-2026-04-01`.
+> **Cost**: Free for management, billable at runtime.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/resources/environment/resource.tf" }}

--- a/templates/resources/message.md.tmpl
+++ b/templates/resources/message.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Sends a message to an Anthropic model via the Messages API and stores the response. All input attributes trigger resource replacement on change.
 
+> **API**: `POST /v1/messages` (Messages API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Billable per apply (consumes tokens).
+
 ~> **Note:** This resource implements an immutable, write-only pattern. There is no persistent storage of messages beyond Terraform state; the resource calls the Anthropic Messages API during `terraform apply` and stores the response. Modifying any input attribute causes the resource to be replaced (a new API call is made). There is no `terraform refresh` from a remote API state.
 
 ## Example Usage

--- a/templates/resources/skill.md.tmpl
+++ b/templates/resources/skill.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a custom Skill on the Anthropic platform (beta). Skills are uploaded from local files and can be attached to Managed Agents.
 
+> **API**: `POST/GET/DELETE /v1/skills[/{id}]` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free for management, billable when used.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/resources/skill/resource.tf" }}

--- a/templates/resources/skill_version.md.tmpl
+++ b/templates/resources/skill_version.md.tmpl
@@ -9,6 +9,11 @@ description: |-
 
 Creates and manages a Skill Version on the Anthropic platform (beta). A Skill Version is created by uploading local files to an existing Skill.
 
+> **API**: `POST/GET/DELETE /v1/skills/{skill_id}/versions[/{version}]` (Skills API).
+> **Auth**: Standard API key (`api_key` / `ANTHROPIC_API_KEY`).
+> **Beta header**: `anthropic-beta: skills-2025-10-02`.
+> **Cost**: Free for management, billable when used.
+
 ## Example Usage
 
 {{ codefile "hcl" "examples/resources/skill_version/resource.tf" }}

--- a/templates/resources/workspace.md.tmpl
+++ b/templates/resources/workspace.md.tmpl
@@ -9,7 +9,10 @@ description: |-
 
 Creates and manages an Anthropic Workspace via the Admin API.
 
-Requires `admin_api_key` (or the `ANTHROPIC_ADMIN_API_KEY` environment variable) to be configured on the provider.
+> **API**: `POST/GET/POST/POST /v1/organizations/workspaces[/{id}][/archive]` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 > **Note on deletion:** Deleting this resource **archives** the workspace rather than permanently deleting it, because the Anthropic API does not expose a delete operation for workspaces. An archived workspace is removed from state and Terraform will recreate it on the next apply.
 

--- a/templates/resources/workspace_member.md.tmpl
+++ b/templates/resources/workspace_member.md.tmpl
@@ -9,7 +9,10 @@ description: |-
 
 Assigns a user to an Anthropic Workspace with a given role via the Admin API.
 
-Requires `admin_api_key` (or the `ANTHROPIC_ADMIN_API_KEY` environment variable) to be configured on the provider.
+> **API**: `POST/GET/POST/DELETE /v1/organizations/workspaces/{workspace_id}/members[/{user_id}]` (Admin API).
+> **Auth**: Admin API key (`admin_api_key` / `ANTHROPIC_ADMIN_API_KEY`).
+> **Beta header**: None.
+> **Cost**: Free.
 
 > **Note:** The `workspace_billing` role cannot be assigned via this resource.
 


### PR DESCRIPTION
## Summary

- Every resource and data source template now carries a four-line blockquote right after the H1 description (before `## Example Usage`) with API endpoint, auth key, beta header, and cost profile — so users immediately know which key to configure and what the billing impact is without reading the provider-level docs.
- `docs/index.md` gains a `## Cost considerations` section warning about unbounded apply-time cost when combining billable resources (`anthropic_message`, Managed Agents, Skills) with `count`/`for_each` or omitting `max_tokens`.
- Duplicate "Requires admin_api_key" prose removed from 4 admin templates (superseded by the standardized block).
- The original issue mapping covered 9 surfaces; this PR extends to all 23, adding `anthropic_environment*`, `anthropic_workspace_member*`, `anthropic_workspace_rate_limits`, and explicit `anthropic_skill_version*` (all added to the provider since the issue was filed).

## Block format

```
> **API**: `<METHOD> /v1/<path>` (<API name>).
> **Auth**: Standard API key | Admin API key (`<arg>` / `<ENV_VAR>`).
> **Beta header**: `anthropic-beta: <value>` | None.
> **Cost**: Free | Free (rate-limited) | Billable per apply | Free for management, billable at runtime.
```

Beta-header strings (`managed-agents-2026-04-01`, `skills-2025-10-02`) verified against `anthropic-sdk-go v1.37.0`.

## Test plan

- [x] `make generate` ran clean — 24 `docs/` files regenerated with the new block in the correct position
- [x] `pre-commit run` on all changed files passed (eof, trailing-whitespace, poutine)
- [ ] Visual spot-check on Terraform Registry preview after merge

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
