### PR TITLE
fix(skills): preserve nested subdirectories in bundle uploads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ r.client = pd.Client
 - `internal/admin/` — HTTP client for Admin API; import as `"github.com/ippontech/terraform-provider-anthropic/internal/admin"`
 - `internal/errors/` (import alias `providerrors`) — nil-client guards for `Configure` methods
 - `internal/providerdata/` (import alias `providerdata`) — `ProviderData` struct
-- `internal/retry/` (import alias `provretry`) — multipart file upload with automatic 5xx retry; use `provretry.MultipartUpload` for any resource that uploads files to the API (the Anthropic SDK cannot retry streaming multipart bodies on its own)
+- `internal/retry/` (import alias `provretry`) — multipart file upload with automatic 5xx retry; use `provretry.MultipartUpload(ctx, filePaths, bundleRoot, dirName, fn)` for any resource that uploads files to the API (the Anthropic SDK cannot retry streaming multipart bodies on its own). Each file's multipart name is `dirName + "/" + <path relative to bundleRoot>` (forward-slash normalised), so nested subdirectories inside a bundle are preserved on upload. Derive `bundleRoot` and `dirName` with `provretry.DeriveBundleRoot(filePaths)` — it returns the longest shared parent, which is order-independent (necessary because `fileset()` returns lexically sorted paths and a nested file like `Assets/icon.png` may sort before `SKILL.md`). Files outside `bundleRoot`, or a path equal to `bundleRoot`, are rejected explicitly
 
 ### archive_on_destroy pattern
 

--- a/docs/resources/skill.md
+++ b/docs/resources/skill.md
@@ -30,7 +30,10 @@ terraform {
 
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
-  files         = ["${path.module}/SKILL.md"]
+  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
+  # The provider preserves each file's path relative to the bundle root so
+  # SKILL.md can reference files in subdirectories at runtime.
+  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
   force_destroy = true
 }
 

--- a/docs/resources/skill.md
+++ b/docs/resources/skill.md
@@ -30,10 +30,15 @@ terraform {
 
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
-  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
-  # The provider preserves each file's path relative to the bundle root so
-  # SKILL.md can reference files in subdirectories at runtime.
-  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  # Explicit patterns avoid sweeping the Terraform config itself into the
+  # bundle. The provider preserves each file's path relative to the bundle
+  # root, so SKILL.md can reference files in subdirectories at runtime.
+  files = [
+    for f in setunion(
+      fileset(path.module, "SKILL.md"),
+      fileset(path.module, "references/**"),
+    ) : "${path.module}/${f}"
+  ]
   force_destroy = true
 }
 

--- a/docs/resources/skill_version.md
+++ b/docs/resources/skill_version.md
@@ -29,13 +29,16 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files         = ["${path.module}/SKILL.md"]
+  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
   force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {
   skill_id = anthropic_skill.example.id
-  files    = ["${path.module}/SKILL.md"]
+  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
+  # The provider preserves each file's path relative to the bundle root so
+  # SKILL.md can reference files in subdirectories at runtime.
+  files = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
 }
 
 output "skill_version_id" {

--- a/docs/resources/skill_version.md
+++ b/docs/resources/skill_version.md
@@ -28,17 +28,26 @@ terraform {
   }
 }
 
+locals {
+  # Explicit patterns avoid sweeping the Terraform config itself into the
+  # bundle. The provider preserves each file's path relative to the bundle
+  # root, so SKILL.md can reference files in subdirectories at runtime.
+  bundle_files = [
+    for f in setunion(
+      fileset(path.module, "SKILL.md"),
+      fileset(path.module, "references/**"),
+    ) : "${path.module}/${f}"
+  ]
+}
+
 resource "anthropic_skill" "example" {
-  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  files         = local.bundle_files
   force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {
   skill_id = anthropic_skill.example.id
-  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
-  # The provider preserves each file's path relative to the bundle root so
-  # SKILL.md can reference files in subdirectories at runtime.
-  files = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  files    = local.bundle_files
 }
 
 output "skill_version_id" {

--- a/examples/resources/skill/SKILL.md
+++ b/examples/resources/skill/SKILL.md
@@ -5,4 +5,5 @@ description: An example custom skill.
 
 # Example Skill
 
-An example custom skill.
+An example custom skill. See `references/template.md` for an example of a
+nested file that the agent can read at runtime.

--- a/examples/resources/skill/references/template.md
+++ b/examples/resources/skill/references/template.md
@@ -1,0 +1,5 @@
+# Example Reference Template
+
+This file lives under `references/` inside the skill bundle. The provider
+preserves the nested path on upload, so SKILL.md can reference it as
+`references/template.md` and the agent will resolve it at runtime.

--- a/examples/resources/skill/resource.tf
+++ b/examples/resources/skill/resource.tf
@@ -11,10 +11,15 @@ terraform {
 
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
-  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
-  # The provider preserves each file's path relative to the bundle root so
-  # SKILL.md can reference files in subdirectories at runtime.
-  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  # Explicit patterns avoid sweeping the Terraform config itself into the
+  # bundle. The provider preserves each file's path relative to the bundle
+  # root, so SKILL.md can reference files in subdirectories at runtime.
+  files = [
+    for f in setunion(
+      fileset(path.module, "SKILL.md"),
+      fileset(path.module, "references/**"),
+    ) : "${path.module}/${f}"
+  ]
   force_destroy = true
 }
 

--- a/examples/resources/skill/resource.tf
+++ b/examples/resources/skill/resource.tf
@@ -11,7 +11,10 @@ terraform {
 
 resource "anthropic_skill" "example" {
   display_title = "Example Skill"
-  files         = ["${path.module}/SKILL.md"]
+  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
+  # The provider preserves each file's path relative to the bundle root so
+  # SKILL.md can reference files in subdirectories at runtime.
+  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
   force_destroy = true
 }
 

--- a/examples/resources/skill_version/SKILL.md
+++ b/examples/resources/skill_version/SKILL.md
@@ -5,4 +5,6 @@ description: An example custom skill version for demonstration.
 
 # Example Skill Version
 
-An example custom skill version for demonstration.
+An example custom skill version for demonstration. See
+`references/template.md` for an example of a nested file that the agent can
+read at runtime.

--- a/examples/resources/skill_version/references/template.md
+++ b/examples/resources/skill_version/references/template.md
@@ -1,0 +1,5 @@
+# Example Reference Template
+
+This file lives under `references/` inside the skill bundle. The provider
+preserves the nested path on upload, so SKILL.md can reference it as
+`references/template.md` and the agent will resolve it at runtime.

--- a/examples/resources/skill_version/resource.tf
+++ b/examples/resources/skill_version/resource.tf
@@ -10,13 +10,16 @@ terraform {
 }
 
 resource "anthropic_skill" "example" {
-  files         = ["${path.module}/SKILL.md"]
+  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
   force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {
   skill_id = anthropic_skill.example.id
-  files    = ["${path.module}/SKILL.md"]
+  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
+  # The provider preserves each file's path relative to the bundle root so
+  # SKILL.md can reference files in subdirectories at runtime.
+  files = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
 }
 
 output "skill_version_id" {

--- a/examples/resources/skill_version/resource.tf
+++ b/examples/resources/skill_version/resource.tf
@@ -9,17 +9,26 @@ terraform {
   }
 }
 
+locals {
+  # Explicit patterns avoid sweeping the Terraform config itself into the
+  # bundle. The provider preserves each file's path relative to the bundle
+  # root, so SKILL.md can reference files in subdirectories at runtime.
+  bundle_files = [
+    for f in setunion(
+      fileset(path.module, "SKILL.md"),
+      fileset(path.module, "references/**"),
+    ) : "${path.module}/${f}"
+  ]
+}
+
 resource "anthropic_skill" "example" {
-  files         = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  files         = local.bundle_files
   force_destroy = true
 }
 
 resource "anthropic_skill_version" "example" {
   skill_id = anthropic_skill.example.id
-  # fileset() picks up SKILL.md and any nested files (e.g. references/*.md).
-  # The provider preserves each file's path relative to the bundle root so
-  # SKILL.md can reference files in subdirectories at runtime.
-  files = [for f in fileset(path.module, "**") : "${path.module}/${f}"]
+  files    = local.bundle_files
 }
 
 output "skill_version_id" {

--- a/internal/retry/bundle_root.go
+++ b/internal/retry/bundle_root.go
@@ -1,0 +1,64 @@
+// Copyright (c) Ippon
+// SPDX-License-Identifier: MPL-2.0
+
+package retry
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// DeriveBundleRoot returns the longest shared parent of filePaths and its
+// base name. Using the common parent (rather than filepath.Dir(filePaths[0]))
+// keeps the result independent of input order — necessary because
+// `fileset()` returns lexicographically sorted paths and a nested file may
+// sort before SKILL.md.
+func DeriveBundleRoot(filePaths []string) (root, dirName string, err error) {
+	if len(filePaths) == 0 {
+		return "", "", fmt.Errorf("DeriveBundleRoot: no file paths provided")
+	}
+
+	root = filepath.Dir(filePaths[0])
+	for _, p := range filePaths[1:] {
+		root = commonPathPrefix(root, filepath.Dir(p))
+		if root == "" {
+			return "", "", fmt.Errorf("DeriveBundleRoot: files do not share a common parent directory: %q vs %q", filePaths[0], p)
+		}
+	}
+
+	dirName = filepath.Base(root)
+	return root, dirName, nil
+}
+
+// commonPathPrefix returns the longest shared parent of a and b, trimmed at
+// a path-segment boundary. Returns "" if they share no segments (e.g.
+// different Windows volumes, or one absolute and one relative).
+func commonPathPrefix(a, b string) string {
+	if a == b {
+		return a
+	}
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	sep := string(filepath.Separator)
+	aSegs := strings.Split(a, sep)
+	bSegs := strings.Split(b, sep)
+	n := len(aSegs)
+	if len(bSegs) < n {
+		n = len(bSegs)
+	}
+	common := 0
+	for common < n && aSegs[common] == bSegs[common] {
+		common++
+	}
+	if common == 0 {
+		return ""
+	}
+	return strings.Join(aSegs[:common], sep)
+}

--- a/internal/retry/bundle_root.go
+++ b/internal/retry/bundle_root.go
@@ -33,7 +33,11 @@ func DeriveBundleRoot(filePaths []string) (root, dirName string, err error) {
 
 // commonPathPrefix returns the longest shared parent of a and b, trimmed at
 // a path-segment boundary. Returns "" if they share no segments (e.g.
-// different Windows volumes, or one absolute and one relative).
+// different Windows volumes, or one absolute and one relative). Note: on
+// POSIX, `/foo` vs `/bar` also yields "" — the leading separator is not
+// treated as a shared segment. This is intentional: a skill bundle whose
+// files live in unrelated trees is not a well-formed bundle and is rejected
+// by DeriveBundleRoot rather than silently rooted at `/`.
 func commonPathPrefix(a, b string) string {
 	if a == b {
 		return a

--- a/internal/retry/bundle_root_test.go
+++ b/internal/retry/bundle_root_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Ippon
+// SPDX-License-Identifier: MPL-2.0
+
+package retry
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeriveBundleRoot_SingleFileAtRoot(t *testing.T) {
+	root, dirName, err := DeriveBundleRoot([]string{filepath.Join("bundle", "SKILL.md")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != "bundle" {
+		t.Errorf("root = %q, want %q", root, "bundle")
+	}
+	if dirName != "bundle" {
+		t.Errorf("dirName = %q, want %q", dirName, "bundle")
+	}
+}
+
+func TestDeriveBundleRoot_MultipleFilesFlat(t *testing.T) {
+	root, dirName, err := DeriveBundleRoot([]string{
+		filepath.Join("bundle", "SKILL.md"),
+		filepath.Join("bundle", "extra.md"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != "bundle" {
+		t.Errorf("root = %q, want %q", root, "bundle")
+	}
+	if dirName != "bundle" {
+		t.Errorf("dirName = %q, want %q", dirName, "bundle")
+	}
+}
+
+func TestDeriveBundleRoot_IndependentOfOrder(t *testing.T) {
+	bundle := "bundle"
+	nested := filepath.Join(bundle, "Assets", "icon.png")
+	skill := filepath.Join(bundle, "SKILL.md")
+
+	rootA, nameA, errA := DeriveBundleRoot([]string{skill, nested})
+	rootB, nameB, errB := DeriveBundleRoot([]string{nested, skill})
+
+	if errA != nil || errB != nil {
+		t.Fatalf("unexpected errors: %v / %v", errA, errB)
+	}
+	if rootA != rootB {
+		t.Errorf("root depends on input order: %q vs %q", rootA, rootB)
+	}
+	if nameA != nameB {
+		t.Errorf("dirName depends on input order: %q vs %q", nameA, nameB)
+	}
+	if rootA != bundle {
+		t.Errorf("root = %q, want %q", rootA, bundle)
+	}
+}
+
+func TestDeriveBundleRoot_DeeplyNestedFiles(t *testing.T) {
+	root, dirName, err := DeriveBundleRoot([]string{
+		filepath.Join("bundle", "SKILL.md"),
+		filepath.Join("bundle", "references", "templates", "report.md"),
+		filepath.Join("bundle", "references", "schemas", "bq.md"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != "bundle" {
+		t.Errorf("root = %q, want %q", root, "bundle")
+	}
+	if dirName != "bundle" {
+		t.Errorf("dirName = %q, want %q", dirName, "bundle")
+	}
+}
+
+func TestDeriveBundleRoot_AbsolutePaths(t *testing.T) {
+	base := string(filepath.Separator) + filepath.Join("tmp", "bundle")
+	root, dirName, err := DeriveBundleRoot([]string{
+		filepath.Join(base, "SKILL.md"),
+		filepath.Join(base, "references", "template.md"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != base {
+		t.Errorf("root = %q, want %q", root, base)
+	}
+	if dirName != "bundle" {
+		t.Errorf("dirName = %q, want %q", dirName, "bundle")
+	}
+}
+
+func TestDeriveBundleRoot_NoCommonParent(t *testing.T) {
+	_, _, err := DeriveBundleRoot([]string{
+		filepath.Join("bundleA", "SKILL.md"),
+		filepath.Join("bundleB", "SKILL.md"),
+	})
+	if err == nil {
+		t.Fatal("expected error when files do not share a common parent")
+	}
+	if !strings.Contains(err.Error(), "common parent") {
+		t.Errorf("expected 'common parent' in error, got %v", err)
+	}
+}
+
+func TestDeriveBundleRoot_EmptyPaths(t *testing.T) {
+	_, _, err := DeriveBundleRoot(nil)
+	if err == nil {
+		t.Fatal("expected error for empty filePaths")
+	}
+}

--- a/internal/retry/bundle_root_test.go
+++ b/internal/retry/bundle_root_test.go
@@ -107,6 +107,25 @@ func TestDeriveBundleRoot_NoCommonParent(t *testing.T) {
 	}
 }
 
+// TestDeriveBundleRoot_BareFilenameNoDirectory documents the behavior when
+// callers pass a file with no directory component (e.g. "SKILL.md" rather
+// than "bundle/SKILL.md"). filepath.Dir returns ".", which propagates to
+// both root and dirName. This matches the pre-strict-path behavior and is
+// kept visible here so any future change to the strict-path check has to
+// consider this case explicitly.
+func TestDeriveBundleRoot_BareFilenameNoDirectory(t *testing.T) {
+	root, dirName, err := DeriveBundleRoot([]string{"SKILL.md"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != "." {
+		t.Errorf("root = %q, want %q", root, ".")
+	}
+	if dirName != "." {
+		t.Errorf("dirName = %q, want %q", dirName, ".")
+	}
+}
+
 func TestDeriveBundleRoot_EmptyPaths(t *testing.T) {
 	_, _, err := DeriveBundleRoot(nil)
 	if err == nil {

--- a/internal/retry/multipart.go
+++ b/internal/retry/multipart.go
@@ -23,8 +23,13 @@ import (
 )
 
 // NamedReader wraps an io.Reader with an explicit multipart filename.
-// The Anthropic SDK encoder checks for Filename() before falling back to
-// the struct field name, which is required for the API to accept the upload.
+//
+// The SDK encoder picks a multipart filename from `Filename() string`,
+// `Name() string` (path.Base'd), then the struct field name — in that
+// order. We embed io.Reader (not *os.File) so the concrete file's
+// Name() is not promoted; otherwise the SDK's path.Base fallback would
+// flatten the bundle layout. The compile-time assertion below locks
+// that contract.
 type NamedReader struct {
 	io.Reader
 	name string
@@ -35,8 +40,9 @@ func NewNamedReader(r io.Reader, filename string) NamedReader {
 	return NamedReader{Reader: r, name: filename}
 }
 
-// Filename satisfies the SDK's optional naming interface.
 func (r NamedReader) Filename() string { return r.name }
+
+var _ interface{ Filename() string } = NamedReader{}
 
 // backoff returns the delay before the given retry attempt.
 // Replaced by tests to avoid real sleeps.
@@ -47,13 +53,15 @@ var backoff = func(attempt int) time.Duration {
 // MultipartUpload opens filePaths fresh on each attempt and calls fn with the
 // resulting readers, retrying up to 3 times on 5xx API errors with backoff.
 //
-// dirName is prepended to each file's base name in the multipart body (the
-// Anthropic API requires all files to live inside a named top-level directory,
-// and that name must match the `name` field in SKILL.md).
+// Each file's multipart name is `dirName + "/" + <relPath>`, where relPath is
+// the file's path relative to bundleRoot in forward-slash form, preserving
+// nested subdirectories. dirName is the top-level directory name in the
+// upload body and must match the `name` field of the bundle's SKILL.md
+// frontmatter.
 //
 // File-open errors and non-5xx API errors are returned immediately without
 // retrying.
-func MultipartUpload[T any](ctx context.Context, filePaths []string, dirName string, fn func([]io.Reader) (T, error)) (T, error) {
+func MultipartUpload[T any](ctx context.Context, filePaths []string, bundleRoot, dirName string, fn func([]io.Reader) (T, error)) (T, error) {
 	const maxAttempts = 3
 	var zero T
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -65,7 +73,7 @@ func MultipartUpload[T any](ctx context.Context, filePaths []string, dirName str
 			}
 		}
 
-		files, openedFiles, err := openFiles(filePaths, dirName)
+		files, openedFiles, err := openFiles(filePaths, bundleRoot, dirName)
 		if err != nil {
 			return zero, err
 		}
@@ -84,17 +92,31 @@ func MultipartUpload[T any](ctx context.Context, filePaths []string, dirName str
 	return zero, nil // unreachable
 }
 
-func openFiles(filePaths []string, dirName string) ([]io.Reader, []*os.File, error) {
+func openFiles(filePaths []string, bundleRoot, dirName string) ([]io.Reader, []*os.File, error) {
 	files := make([]io.Reader, 0, len(filePaths))
 	opened := make([]*os.File, 0, len(filePaths))
 	for _, p := range filePaths {
+		rel, err := filepath.Rel(bundleRoot, p)
+		if err != nil {
+			closeAll(opened)
+			return nil, nil, fmt.Errorf("unable to compute path of %q relative to bundle root %q: %w", p, bundleRoot, err)
+		}
+		// IsLocal also returns true for ".", which means the file path equals
+		// bundleRoot and is nonsensical as an upload — reject it explicitly.
+		if rel == "." || !filepath.IsLocal(rel) {
+			closeAll(opened)
+			return nil, nil, fmt.Errorf("file %q is not inside bundle root %q (relative path: %q)", p, bundleRoot, rel)
+		}
 		f, err := os.Open(p)
 		if err != nil {
 			closeAll(opened)
 			return nil, nil, fmt.Errorf("unable to open file %q: %w", p, err)
 		}
 		opened = append(opened, f)
-		files = append(files, NewNamedReader(f, dirName+"/"+filepath.Base(p)))
+		// The API requires forward slashes; normalise so Windows-built
+		// binaries do not emit backslash names.
+		uploadName := dirName + "/" + filepath.ToSlash(rel)
+		files = append(files, NewNamedReader(f, uploadName))
 	}
 	return files, opened, nil
 }

--- a/internal/retry/multipart_test.go
+++ b/internal/retry/multipart_test.go
@@ -40,7 +40,10 @@ func apiErr(statusCode int) *anthropic.Error {
 func writeFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	p := filepath.Join(dir, name)
-	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("writeFile mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 		t.Fatalf("writeFile: %v", err)
 	}
 	return p
@@ -73,7 +76,7 @@ func TestMultipartUpload_SuccessOnFirstAttempt(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	calls := 0
-	result, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	result, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "ok", nil
 	})
@@ -95,7 +98,7 @@ func TestMultipartUpload_RetriesOn5xx(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	calls := 0
-	result, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	result, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		if calls < 2 {
 			return "", apiErr(500)
@@ -120,7 +123,7 @@ func TestMultipartUpload_ExhaustsMaxAttempts(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	calls := 0
-	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "", apiErr(503)
 	})
@@ -142,7 +145,7 @@ func TestMultipartUpload_NoRetryOn4xx(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	calls := 0
-	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "", apiErr(400)
 	})
@@ -160,7 +163,7 @@ func TestMultipartUpload_NoRetryOnNonAPIError(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	calls := 0
-	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "", errors.New("connection reset")
 	})
@@ -175,7 +178,7 @@ func TestMultipartUpload_NoRetryOnNonAPIError(t *testing.T) {
 
 func TestMultipartUpload_FileOpenError(t *testing.T) {
 	calls := 0
-	_, err := MultipartUpload(context.Background(), []string{"/nonexistent/path/SKILL.md"}, "mydir", func(_ []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{"/nonexistent/path/SKILL.md"}, "/nonexistent/path", "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "ok", nil
 	})
@@ -199,7 +202,7 @@ func TestMultipartUpload_ContextCancelledDuringBackoff(t *testing.T) {
 	cancel() // pre-cancel so the backoff select fires immediately on attempt 1
 
 	calls := 0
-	_, err := MultipartUpload(ctx, []string{p}, "mydir", func(_ []io.Reader) (string, error) {
+	_, err := MultipartUpload(ctx, []string{p}, dir, "mydir", func(_ []io.Reader) (string, error) {
 		calls++
 		return "", apiErr(500) // triggers a retry attempt
 	})
@@ -217,12 +220,17 @@ func TestMultipartUpload_FileNamingUseDirName(t *testing.T) {
 	p := writeFile(t, dir, "SKILL.md", "content")
 
 	var gotFilename string
-	_, _ = MultipartUpload(context.Background(), []string{p}, "myskill", func(files []io.Reader) (string, error) {
-		if named, ok := files[0].(interface{ Filename() string }); ok {
-			gotFilename = named.Filename()
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "myskill", func(files []io.Reader) (string, error) {
+		named, ok := files[0].(interface{ Filename() string })
+		if !ok {
+			t.Fatalf("reader does not satisfy Filename(): %T", files[0])
 		}
+		gotFilename = named.Filename()
 		return "ok", nil
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	want := "myskill/SKILL.md"
 	if gotFilename != want {
@@ -230,11 +238,68 @@ func TestMultipartUpload_FileNamingUseDirName(t *testing.T) {
 	}
 }
 
+func TestMultipartUpload_PreservesNestedSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	skillPath := writeFile(t, dir, "SKILL.md", "skill")
+	refPath := writeFile(t, dir, "references/template.md", "template")
+
+	var gotFilenames []string
+	_, err := MultipartUpload(context.Background(), []string{skillPath, refPath}, dir, "myskill", func(files []io.Reader) (string, error) {
+		for i, f := range files {
+			named, ok := f.(interface{ Filename() string })
+			if !ok {
+				t.Fatalf("reader[%d] does not satisfy Filename(): %T", i, f)
+			}
+			gotFilenames = append(gotFilenames, named.Filename())
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantFilenames := []string{
+		"myskill/SKILL.md",
+		"myskill/references/template.md",
+	}
+	if len(gotFilenames) != len(wantFilenames) {
+		t.Fatalf("got %d filenames, want %d (%v)", len(gotFilenames), len(wantFilenames), gotFilenames)
+	}
+	for i, want := range wantFilenames {
+		if gotFilenames[i] != want {
+			t.Errorf("filename[%d] = %q, want %q", i, gotFilenames[i], want)
+		}
+	}
+}
+
+func TestMultipartUpload_RejectsFileOutsideBundleRoot(t *testing.T) {
+	outerDir := t.TempDir()
+	innerDir := filepath.Join(outerDir, "bundle")
+	outsidePath := writeFile(t, outerDir, "outside.md", "x")
+	insidePath := writeFile(t, innerDir, "SKILL.md", "s")
+
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{insidePath, outsidePath}, innerDir, "myskill", func(_ []io.Reader) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	if err == nil {
+		t.Fatal("expected error when file lies outside bundleRoot")
+	}
+	if !strings.Contains(err.Error(), "not inside bundle root") {
+		t.Errorf("expected 'not inside bundle root' in error, got: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("fn called %d times, want 0", calls)
+	}
+}
+
 func TestMultipartUpload_FileContentReadable(t *testing.T) {
 	dir := t.TempDir()
 	p := writeFile(t, dir, "SKILL.md", "---\nname: test\n---\n")
 
-	_, err := MultipartUpload(context.Background(), []string{p}, "mydir", func(files []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(files []io.Reader) (string, error) {
 		data, err := io.ReadAll(files[0])
 		if err != nil {
 			return "", err
@@ -253,13 +318,36 @@ func TestMultipartUpload_MultipleFiles(t *testing.T) {
 	p2 := writeFile(t, dir, "extra.md", "extra content")
 
 	var gotCount int
-	_, _ = MultipartUpload(context.Background(), []string{p1, p2}, "mydir", func(files []io.Reader) (string, error) {
+	_, err := MultipartUpload(context.Background(), []string{p1, p2}, dir, "mydir", func(files []io.Reader) (string, error) {
 		gotCount = len(files)
 		return "ok", nil
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if gotCount != 2 {
 		t.Errorf("fn received %d files, want 2", gotCount)
+	}
+}
+
+func TestMultipartUpload_RejectsBundleRootItselfAsFile(t *testing.T) {
+	dir := t.TempDir()
+
+	calls := 0
+	_, err := MultipartUpload(context.Background(), []string{dir}, dir, "myskill", func(_ []io.Reader) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	if err == nil {
+		t.Fatal("expected error when file path equals bundleRoot")
+	}
+	if !strings.Contains(err.Error(), "not inside bundle root") {
+		t.Errorf("expected 'not inside bundle root' in error, got: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("fn called %d times, want 0", calls)
 	}
 }
 
@@ -270,14 +358,20 @@ func TestMultipartUpload_FilesReopenedOnRetry(t *testing.T) {
 
 	// Collect all file reads across attempts to confirm fresh opens on each retry.
 	var contents []string
-	MultipartUpload(context.Background(), []string{p}, "mydir", func(files []io.Reader) (string, error) { //nolint:errcheck
-		data, _ := io.ReadAll(files[0])
+	_, err := MultipartUpload(context.Background(), []string{p}, dir, "mydir", func(files []io.Reader) (string, error) {
+		data, readErr := io.ReadAll(files[0])
+		if readErr != nil {
+			return "", readErr
+		}
 		contents = append(contents, string(data))
 		if len(contents) < 2 {
 			return "", apiErr(500)
 		}
 		return "ok", nil
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	for i, c := range contents {
 		if c != "data" {

--- a/internal/services/skills/skill_resource.go
+++ b/internal/services/skills/skill_resource.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -147,12 +146,13 @@ func (r *SkillResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// The API requires every file to live inside a named top-level directory
-	// (e.g. "myskill/SKILL.md"). We derive that directory name from the common
-	// parent of the provided paths.
-	dirName := filepath.Base(filepath.Dir(filePaths[0]))
+	bundleRoot, dirName, err := provretry.DeriveBundleRoot(filePaths)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid skill bundle", err.Error())
+		return
+	}
 
-	skill, err := provretry.MultipartUpload(ctx, filePaths, dirName, func(files []io.Reader) (*anthropic.BetaSkillNewResponse, error) {
+	skill, err := provretry.MultipartUpload(ctx, filePaths, bundleRoot, dirName, func(files []io.Reader) (*anthropic.BetaSkillNewResponse, error) {
 		params := anthropic.BetaSkillNewParams{Files: files}
 		if !data.DisplayTitle.IsNull() && !data.DisplayTitle.IsUnknown() {
 			params.DisplayTitle = anthropic.String(data.DisplayTitle.ValueString())

--- a/internal/services/skills/skill_version_resource.go
+++ b/internal/services/skills/skill_version_resource.go
@@ -8,16 +8,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	providerrors "github.com/ippontech/terraform-provider-anthropic/internal/errors"
 	providerdata "github.com/ippontech/terraform-provider-anthropic/internal/providerdata"
@@ -73,6 +74,7 @@ func (r *SkillVersionResource) Schema(_ context.Context, _ resource.SchemaReques
 				ElementType:         types.StringType,
 				MarkdownDescription: "Local file paths to upload for the skill version. Must include a `SKILL.md` file at the root of the directory.",
 				PlanModifiers:       []planmodifier.List{listplanmodifier.RequiresReplace()},
+				Validators:          []validator.List{listvalidator.SizeAtLeast(1)},
 			},
 			"version": schema.StringAttribute{
 				Computed:            true,
@@ -137,9 +139,13 @@ func (r *SkillVersionResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	dirName := filepath.Base(filepath.Dir(filePaths[0]))
+	bundleRoot, dirName, err := provretry.DeriveBundleRoot(filePaths)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid skill bundle", err.Error())
+		return
+	}
 
-	skillVersion, err := provretry.MultipartUpload(ctx, filePaths, dirName, func(files []io.Reader) (*anthropic.BetaSkillVersionNewResponse, error) {
+	skillVersion, err := provretry.MultipartUpload(ctx, filePaths, bundleRoot, dirName, func(files []io.Reader) (*anthropic.BetaSkillVersionNewResponse, error) {
 		return r.client.Beta.Skills.Versions.New(ctx, data.SkillID.ValueString(), anthropic.BetaSkillVersionNewParams{
 			Files: files,
 		})


### PR DESCRIPTION
## Summary

`internal/retry/multipart.go` previously named each multipart file as `<dirName>/<basename>`, which flattened any nested subdirectory inside a skill bundle. Files such as `references/template.md` were uploaded as `<skill>/template.md`, breaking SKILL.md cross-references that resolve to `references/template.md` at agent runtime (e.g. `awk` / `cat` on the referenced path inside `/workspace/skills/<skill>/`).

This PR threads the bundle root through `MultipartUpload` and uses `filepath.Rel(bundleRoot, p)` so each multipart name preserves the relative path. Forward slashes are normalised so Windows-built binaries do not emit backslash names. Files outside the declared bundle root now return an explicit error instead of silently flattening to a basename.

## Why

The Anthropic API accepts nested layouts — files can be uploaded with names like `<skill>/references/template.md` and they appear at the same relative path inside `/workspace/skills/<skill>/` at agent runtime. The provider was silently flattening to basenames, so any SKILL.md referencing a file in a subdirectory broke at runtime with `No such file or directory`. The bug affected both `anthropic_skill` (initial create) and `anthropic_skill_version` (subsequent versions) since both call the same `MultipartUpload` helper.

## Changes

### Core fix

- `internal/retry/multipart.go`
  - `MultipartUpload` now takes `bundleRoot` alongside `dirName`.
  - `openFiles` computes each file's name as `dirName + \"/\" + filepath.ToSlash(filepath.Rel(bundleRoot, p))` so nested subdirectories survive the upload.
  - `filepath.IsLocal` (Go 1.20+) is used to reject paths that escape `bundleRoot`; the only case it accepts that still needs to be rejected is `.` (file equals bundleRoot), which is kept as an explicit clause.
  - `NamedReader` is documented to embed `io.Reader` (not `*os.File`) so the SDK encoder reaches the explicit `Filename()` override instead of falling back to `path.Base(Name())`. A compile-time assertion locks the contract.

- `internal/retry/bundle_root.go` (new)
  - `DeriveBundleRoot(filePaths) (root, dirName string, error)` returns the longest shared parent of `filePaths`, which is independent of input order. Using `filepath.Dir(filePaths[0])` was order-dependent: `fileset()` returns lexically sorted paths, so a top-level subdirectory whose name sorts before `SKILL.md` (e.g. `Assets/`) would make the first file a nested one and break every other file with the new strict path check.

- `internal/services/skills/skill_resource.go` and `skill_version_resource.go`
  - Switched to `DeriveBundleRoot(filePaths)` and pass both `bundleRoot` and `dirName` to `MultipartUpload`.

### Defense-in-depth

- `internal/services/skills/skill_version_resource.go`
  - Added `Validators: []validator.List{listvalidator.SizeAtLeast(1)}` on the `files` attribute. `skill_resource.go` already had this; the version variant did not, so `files = []` would index past `filePaths[0]` and panic the provider.

### Tests

- `TestMultipartUpload_PreservesNestedSubdirectories` is the regression test for the flattening bug.
- `TestMultipartUpload_RejectsFileOutsideBundleRoot` and `TestMultipartUpload_RejectsBundleRootItselfAsFile` cover the two branches of the new relative-path check.
- `internal/retry/bundle_root_test.go` covers `DeriveBundleRoot`'s flat-bundle, deeply-nested, order-independence, absolute-path, no-common-parent, and empty-input cases.
- Existing `MultipartUpload` tests now assert the error return so a future regression in `openFiles` surfaces directly instead of as a misleading length-mismatch.

## Compatibility

- The exported `MultipartUpload` signature changed (`bundleRoot` added before `dirName`). The function lives under `internal/` so the change is internal to the provider.
- Behaviour for bundles whose files all sit at the top of `bundleRoot` is unchanged: `filepath.Rel(root, root/file)` returns the basename, so the multipart name is identical to before.

## Test plan

- [x] `go test ./internal/retry/... ./internal/services/skills/...` passes locally
- [x] `go build ./...` and `go vet ./...` clean
- [x] Live upload against the Anthropic API with a bundle containing `SKILL.md` and `references/template.md` — both paths are preserved in the uploaded version (confirmed via runtime resolution of `references/template.md` inside an agent session)