### PR TITLE
fix(agents): use jsontypes.Normalized for custom_tool input_schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,35 @@ func testAccCheck<Resource>ArchivedAndCleanup(s *terraform.State) error {
 }
 ```
 
+### jsontypes.Normalized for JSON string attributes
+
+Any schema attribute that stores a JSON string and is `Optional` (not `Computed`) must use `jsontypes.NormalizedType{}` as its `CustomType` and `jsontypes.Normalized` as the Go model field type. Plain `types.String` causes "Provider produced inconsistent result after apply" whenever the API response JSON differs from the user's `jsonencode()` output in key order or whitespace.
+
+```go
+// Schema attribute
+"input_schema": schema.StringAttribute{
+    Optional:   true,
+    CustomType: jsontypes.NormalizedType{},
+    ...
+},
+
+// Model field
+InputSchema jsontypes.Normalized `tfsdk:"input_schema"`
+
+// Attr-type map
+"input_schema": jsontypes.NormalizedType{}
+
+// State mapping — use RawJSON() to avoid double-marshal artifacts
+inputSchema := jsontypes.NewNormalizedNull()
+if raw := t.SomeField.RawJSON(); raw != "" && raw != "null" {
+    inputSchema = jsontypes.NewNormalizedValue(raw)
+}
+```
+
+Import: `"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"` (dependency: `terraform-plugin-framework-jsontypes v0.2.0`).
+
+Do **not** use `json.Marshal(sdkStruct)` to populate a string attribute in state — SDK upgrades can change struct field order or add new fields, silently breaking plan/apply consistency.
+
 ### Version constraints
 
 Provider is on major version 1.x. Always use `~> 1.0` in example configs — never `~> 0.1.0`.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/anthropics/anthropic-sdk-go v1.51.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
 github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=

--- a/internal/services/agents/agent_data_source.go
+++ b/internal/services/agents/agent_data_source.go
@@ -5,11 +5,11 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -221,6 +221,7 @@ func (d *AgentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 						},
 						"input_schema": schema.StringAttribute{
 							Computed:            true,
+							CustomType:          jsontypes.NormalizedType{},
 							MarkdownDescription: "JSON Schema for the tool's input parameters.",
 						},
 					},
@@ -416,12 +417,9 @@ func mapAgentResponseToDataSource(agent *anthropic.BetaManagedAgentsAgent, data 
 	if len(apiCustomTools) > 0 {
 		toolObjs := make([]attr.Value, len(apiCustomTools))
 		for i, t := range apiCustomTools {
-			inputSchema := types.StringNull()
-			if t.InputSchema.Properties != nil || len(t.InputSchema.Required) > 0 || t.InputSchema.Type != "" {
-				schemaJSON, err := json.Marshal(t.InputSchema)
-				if err == nil {
-					inputSchema = types.StringValue(string(schemaJSON))
-				}
+			inputSchema := jsontypes.NewNormalizedNull()
+			if raw := t.InputSchema.RawJSON(); raw != "" && raw != "null" {
+				inputSchema = jsontypes.NewNormalizedValue(raw)
 			}
 			obj, d := types.ObjectValue(agentCustomToolAttrTypes, map[string]attr.Value{
 				"name":         types.StringValue(t.Name),

--- a/internal/services/agents/agent_resource.go
+++ b/internal/services/agents/agent_resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -92,9 +93,9 @@ type agentMCPToolsetModel struct {
 }
 
 type agentCustomToolModel struct {
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	InputSchema types.String `tfsdk:"input_schema"`
+	Name        types.String         `tfsdk:"name"`
+	Description types.String         `tfsdk:"description"`
+	InputSchema jsontypes.Normalized `tfsdk:"input_schema"`
 }
 
 // --- Attribute type maps for nested objects ---
@@ -138,7 +139,7 @@ var agentMCPToolsetAttrTypes = map[string]attr.Type{
 var agentCustomToolAttrTypes = map[string]attr.Type{
 	"name":         types.StringType,
 	"description":  types.StringType,
-	"input_schema": types.StringType,
+	"input_schema": jsontypes.NormalizedType{},
 }
 
 // --- Permission policy validators (reused across tool schemas) ---
@@ -326,6 +327,7 @@ func (r *AgentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						},
 						"input_schema": schema.StringAttribute{
 							Optional:            true,
+							CustomType:          jsontypes.NormalizedType{},
 							MarkdownDescription: "JSON Schema for the tool's input parameters. Use `jsonencode()` to build the value.",
 						},
 					},
@@ -925,12 +927,9 @@ func mapAgentResponseToState(ctx context.Context, agent *anthropic.BetaManagedAg
 	if len(apiCustomTools) > 0 {
 		toolObjs := make([]attr.Value, len(apiCustomTools))
 		for i, t := range apiCustomTools {
-			inputSchema := types.StringNull()
-			if t.InputSchema.Properties != nil || len(t.InputSchema.Required) > 0 || t.InputSchema.Type != "" {
-				schemaJSON, err := json.Marshal(t.InputSchema)
-				if err == nil {
-					inputSchema = types.StringValue(string(schemaJSON))
-				}
+			inputSchema := jsontypes.NewNormalizedNull()
+			if raw := t.InputSchema.RawJSON(); raw != "" && raw != "null" {
+				inputSchema = jsontypes.NewNormalizedValue(raw)
 			}
 			obj, d := types.ObjectValue(agentCustomToolAttrTypes, map[string]attr.Value{
 				"name":         types.StringValue(t.Name),

--- a/internal/services/agents/agent_resource_mapping_test.go
+++ b/internal/services/agents/agent_resource_mapping_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) Ippon
+// SPDX-License-Identifier: MPL-2.0
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// TestMapAgentResponseToState_customToolInputSchema is a regression test for the
+// anthropic-sdk-go upgrade (v1.37 -> v1.51) that changed how the
+// BetaManagedAgentsCustomToolInputSchema struct marshals: field reordering plus a
+// spurious "ExtraFields":null key. Re-marshaling the parsed schema with
+// encoding/json produced a state value that no longer matched the user's planned
+// input_schema string, triggering "Provider produced inconsistent result after
+// apply". The mapping now preserves the raw API JSON via RawJSON() and stores it
+// as a jsontypes.Normalized value, so semantic (key-order-insensitive) equality
+// holds against the user's jsonencode() output.
+func TestMapAgentResponseToState_customToolInputSchema(t *testing.T) {
+	t.Parallel()
+
+	// API response schema: "type" first, no ExtraFields key.
+	const apiInputSchema = `{"type":"object","properties":{"email":{"description":"The user's email address","type":"string"}},"required":["email"]}`
+
+	agentJSON := `{
+		"id": "agent_123",
+		"name": "test",
+		"model": {"id": "claude-sonnet-4-6"},
+		"version": 1,
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z",
+		"tools": [
+			{
+				"type": "custom",
+				"name": "lookup_user",
+				"description": "Look up a user",
+				"input_schema": ` + apiInputSchema + `
+			}
+		]
+	}`
+
+	var agent anthropic.BetaManagedAgentsAgent
+	if err := json.Unmarshal([]byte(agentJSON), &agent); err != nil {
+		t.Fatalf("failed to unmarshal agent fixture: %s", err)
+	}
+
+	var data AgentResourceModel
+	if diags := mapAgentResponseToState(context.Background(), &agent, &data); diags.HasError() {
+		t.Fatalf("mapAgentResponseToState returned errors: %+v", diags)
+	}
+
+	var tools []agentCustomToolModel
+	if diags := data.CustomTools.ElementsAs(context.Background(), &tools, false); diags.HasError() {
+		t.Fatalf("failed to read custom tools: %+v", diags)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 custom tool, got %d", len(tools))
+	}
+
+	got := tools[0].InputSchema
+	if got.IsNull() || got.IsUnknown() {
+		t.Fatalf("input_schema should be set, got null/unknown")
+	}
+
+	// The state value must not contain the encoding/json artifact that broke
+	// round-tripping under the SDK upgrade.
+	if strings.Contains(got.ValueString(), "ExtraFields") {
+		t.Errorf("input_schema must not contain ExtraFields; got %q", got.ValueString())
+	}
+
+	// Semantic equality must hold against the user's jsonencode() output, which
+	// orders keys alphabetically (properties, required, type) — a different order
+	// than the API response. Without jsontypes.Normalized this mismatch is what
+	// surfaced as "inconsistent result after apply".
+	const userInputSchema = `{"properties":{"email":{"description":"The user's email address","type":"string"}},"required":["email"],"type":"object"}`
+	planned := jsontypes.NewNormalizedValue(userInputSchema)
+	equal, diags := planned.StringSemanticEquals(context.Background(), got)
+	if diags.HasError() {
+		t.Fatalf("semantic equality check returned errors: %+v", diags)
+	}
+	if !equal {
+		t.Errorf("planned and applied input_schema should be semantically equal\nplanned: %s\napplied: %s", userInputSchema, got.ValueString())
+	}
+}

--- a/internal/services/agents/agents_data_source.go
+++ b/internal/services/agents/agents_data_source.go
@@ -5,12 +5,12 @@ package agents
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -249,6 +249,7 @@ func (d *AgentsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 									},
 									"input_schema": schema.StringAttribute{
 										Computed:            true,
+										CustomType:          jsontypes.NormalizedType{},
 										MarkdownDescription: "JSON Schema for the tool's input parameters, encoded as a JSON string.",
 									},
 								},
@@ -479,11 +480,9 @@ func mapAgentToDataSourceObject(agent *anthropic.BetaManagedAgentsAgent) (attr.V
 	if len(apiCustomTools) > 0 {
 		objs := make([]attr.Value, len(apiCustomTools))
 		for i, t := range apiCustomTools {
-			inputSchema := types.StringNull()
-			if t.InputSchema.Properties != nil || len(t.InputSchema.Required) > 0 || t.InputSchema.Type != "" {
-				if schemaJSON, err := json.Marshal(t.InputSchema); err == nil {
-					inputSchema = types.StringValue(string(schemaJSON))
-				}
+			inputSchema := jsontypes.NewNormalizedNull()
+			if raw := t.InputSchema.RawJSON(); raw != "" && raw != "null" {
+				inputSchema = jsontypes.NewNormalizedValue(raw)
 			}
 			obj, d := types.ObjectValue(agentCustomToolAttrTypes, map[string]attr.Value{
 				"name":         types.StringValue(t.Name),


### PR DESCRIPTION
## Root cause

PR #133 bumped `anthropic-sdk-go` v1.37 → v1.51. That SDK release changed how `BetaManagedAgentsCustomToolInputSchema` marshals: field order changed (`properties, required, type` → `type, properties, required`) and a new `ExtraFields map[string]any` field emits a spurious `"ExtraFields":null` key.

The resource and data sources stored `input_schema` into state via `json.Marshal(t.InputSchema)`. Post-upgrade that produced `{"type":"object",...,"ExtraFields":null}`, which no longer matched the user's planned `jsonencode()` string. Since `input_schema` is `Optional` (not `Computed`), Terraform rejected the mismatch with _"Provider produced inconsistent result after apply"_, breaking `TestAccAgentResource_withCustomTools`.

## Fix

Two coordinated changes across `agent_resource.go`, `agent_data_source.go`, `agents_data_source.go`:

- **`jsontypes.Normalized`** for the `input_schema` attribute (model field, attr-type map, schema `CustomType`). Gives semantic JSON equality (key-order/whitespace-insensitive), so the framework treats planned and applied values as equal when they are semantically identical — the correct remedy for this class of inconsistency.
- **`t.InputSchema.RawJSON()`** instead of `json.Marshal(...)` — preserves the exact API response bytes, eliminating the `ExtraFields:null` artifact.

Adds a regression unit test (`agent_resource_mapping_test.go`) asserting: (1) no `ExtraFields` key in state, and (2) semantic equality holds between a reordered (jsonencode-style) planned value and the API-response-derived applied value.

Documents the `jsontypes.Normalized` convention in `CLAUDE.md` so future JSON string attributes follow the same pattern.

## Verification

- `go build ./...` — OK
- `make lint` — 0 issues
- Full unit suite — **93 passed** (incl. new regression test)
- `make generate` — no doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)